### PR TITLE
Applied patch to abstract from lucene indexing

### DIFF
--- a/src/org/opencms/search/CmsIndexingThreadManager.java
+++ b/src/org/opencms/search/CmsIndexingThreadManager.java
@@ -37,7 +37,6 @@ import java.io.IOException;
 
 import org.apache.commons.logging.Log;
 import org.apache.lucene.document.Document;
-import org.apache.lucene.index.IndexWriter;
 
 /**
  * Implements the management of indexing threads.<p>
@@ -94,7 +93,7 @@ public class CmsIndexingThreadManager {
      * @param writer the index writer that can update the index
      * @param res the resource
      */
-    public void createIndexingThread(CmsVfsIndexer indexer, IndexWriter writer, CmsResource res) {
+    public void createIndexingThread(CmsVfsIndexer indexer, I_CmsIndexWriter writer, CmsResource res) {
 
         I_CmsReport report = indexer.getReport();
         m_startedCounter++;

--- a/src/org/opencms/search/CmsLuceneIndexWriter.java
+++ b/src/org/opencms/search/CmsLuceneIndexWriter.java
@@ -1,0 +1,44 @@
+package org.opencms.search;
+
+import java.io.IOException;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.Term;
+import org.opencms.search.fields.CmsSearchField;
+
+/**
+ * Delegates indexing to a lucene IndexWriter.
+ * @author Florian Hopf, Synyx GmbH & Co. KG, hopf@synyx.de
+ */
+public class CmsLuceneIndexWriter implements I_CmsIndexWriter {
+
+    private final IndexWriter indexWriter;
+
+    public CmsLuceneIndexWriter(IndexWriter indexWriter) {
+        this.indexWriter = indexWriter;
+
+    }
+
+    public void optimize() throws IOException {
+        indexWriter.optimize();
+    }
+
+    public void commit() throws IOException {
+        indexWriter.commit();
+    }
+
+    public void close() throws IOException {
+        indexWriter.close();
+    }
+
+    public void updateDocument(String path, Document document) throws IOException {
+        Term pathTerm = new Term(CmsSearchField.FIELD_PATH, path);
+        indexWriter.updateDocument(pathTerm, document);
+    }
+
+    public void deleteDocuments(String rootPath) throws IOException {
+        // search for an exact match on the document root path
+        Term term = new Term(CmsSearchField.FIELD_PATH, rootPath);
+        indexWriter.deleteDocuments(term);
+    }
+}

--- a/src/org/opencms/search/CmsSearchIndex.java
+++ b/src/org/opencms/search/CmsSearchIndex.java
@@ -786,7 +786,7 @@ public class CmsSearchIndex implements I_CmsConfigurationParameterHandler {
      * @return a new instance of IndexWriter
      * @throws CmsIndexException if the index can not be opened
      */
-    public IndexWriter getIndexWriter(boolean create) throws CmsIndexException {
+    public I_CmsIndexWriter getIndexWriter(boolean create) throws CmsIndexException {
 
         IndexWriter indexWriter;
 
@@ -837,7 +837,7 @@ public class CmsSearchIndex implements I_CmsConfigurationParameterHandler {
                 e);
         }
 
-        return indexWriter;
+        return new CmsLuceneIndexWriter(indexWriter);
     }
 
     /**

--- a/src/org/opencms/search/CmsSearchManager.java
+++ b/src/org/opencms/search/CmsSearchManager.java
@@ -2064,7 +2064,7 @@ public class CmsSearchManager implements I_CmsScheduledJob, I_CmsEventListener {
                 initOfflineIndexes();
             }
 
-            IndexWriter writer = null;
+            I_CmsIndexWriter writer = null;
             try {
                 // create a backup of the existing index
                 String backup = index.createIndexBackup();
@@ -2212,7 +2212,7 @@ public class CmsSearchManager implements I_CmsScheduledJob, I_CmsEventListener {
             // unlock the index
             forceIndexUnlock(index, report, true);
 
-            IndexWriter writer = null;
+            I_CmsIndexWriter writer = null;
             try {
                 // obtain an index writer that updates the current index
                 writer = index.getIndexWriter(false);

--- a/src/org/opencms/search/CmsSearchResult.java
+++ b/src/org/opencms/search/CmsSearchResult.java
@@ -68,7 +68,7 @@ public class CmsSearchResult implements I_CmsMemoryMonitorable, Comparable<CmsSe
     protected int m_score;
 
     /** Holds the values of the search result fields. */
-    Map<String, String> m_fields;
+    protected Map<String, String> m_fields;
 
     /** Contains the pre-calculated memory size. */
     private int m_memorySize;
@@ -138,6 +138,13 @@ public class CmsSearchResult implements I_CmsMemoryMonitorable, Comparable<CmsSe
         } else {
             m_documentType = null;
         }
+    }
+
+    /**
+     * Empty constructor to be used for overriding classes.
+     */
+    protected CmsSearchResult() {
+        
     }
 
     /**

--- a/src/org/opencms/search/I_CmsIndexWriter.java
+++ b/src/org/opencms/search/I_CmsIndexWriter.java
@@ -1,0 +1,45 @@
+package org.opencms.search;
+
+import java.io.IOException;
+import org.apache.lucene.document.Document;
+
+/**
+ * Provides index manipulation operations.
+ * @author Florian Hopf, Synyx GmbH & Co. KG, hopf@synyx.de
+ */
+public interface I_CmsIndexWriter {
+
+    /**
+     * Optimizes the index.
+     * @throws IOException
+     */
+    void optimize() throws IOException;
+
+    /**
+     * Commit all previous operations.
+     * @throws IOException
+     */
+    void commit() throws IOException;
+
+    /**
+     * Close this IndexWriter.
+     * @throws IOException
+     */
+    void close() throws IOException;
+
+    /**
+     * Update a document in the index.
+     * @param path
+     * @param document
+     * @throws IOException
+     */
+    void updateDocument(String path, Document document) throws IOException;
+
+    /**
+     * Delete a document from the index.
+     * @param rootPath
+     * @throws IOException
+     */
+    void deleteDocuments(String rootPath) throws IOException;
+
+}

--- a/src/org/opencms/search/I_CmsIndexer.java
+++ b/src/org/opencms/search/I_CmsIndexer.java
@@ -33,8 +33,6 @@ import org.opencms.report.I_CmsReport;
 
 import java.util.List;
 
-import org.apache.lucene.index.IndexWriter;
-
 /**
  * Indexes resources for the OpenCms search.<p>
  * 
@@ -53,7 +51,7 @@ public interface I_CmsIndexer {
      * 
      * @throws CmsIndexException if something goes wrong
      */
-    void deleteResources(IndexWriter indexWriter, List<CmsPublishedResource> resourcesToDelete)
+    void deleteResources(I_CmsIndexWriter indexWriter, List<CmsPublishedResource> resourcesToDelete)
     throws CmsIndexException;
 
     /**
@@ -92,7 +90,7 @@ public interface I_CmsIndexer {
      * 
      * @throws CmsIndexException if something goes wrong
      */
-    void rebuildIndex(IndexWriter writer, CmsIndexingThreadManager threadManager, CmsSearchIndexSource source)
+    void rebuildIndex(I_CmsIndexWriter writer, CmsIndexingThreadManager threadManager, CmsSearchIndexSource source)
     throws CmsIndexException;
 
     /**
@@ -105,7 +103,7 @@ public interface I_CmsIndexer {
      * @throws CmsIndexException if something goes wrong
      */
     void updateResources(
-        IndexWriter writer,
+        I_CmsIndexWriter writer,
         CmsIndexingThreadManager threadManager,
         List<CmsPublishedResource> resourcesToUpdate) throws CmsIndexException;
 }


### PR DESCRIPTION
This makes it possible to use different search engines, notably Apache Solr with the module available at https://redmine.synyx.org/projects/opencms-solr-module/. See http://bugzilla.opencms.org/show_bug.cgi?id=1950 for the initial feature request.
