### PR TITLE
getFactory() method is expected to be used by module developers who use

### DIFF
--- a/src/org/opencms/db/jpa/CmsSqlManager.java
+++ b/src/org/opencms/db/jpa/CmsSqlManager.java
@@ -276,7 +276,7 @@ public class CmsSqlManager extends org.opencms.db.CmsSqlManager {
 
         EntityManagerFactory factory = m_factoryTable.get(unitName);
         if (factory == null) {
-            factory = Persistence.createEntityManagerFactory(unitName, System.getProperties());
+            factory = Persistence.createEntityManagerFactory(unitName);
             m_factoryTable.put(unitName, factory);
         }
         return factory;


### PR DESCRIPTION
getFactory() method is expected to be used by module developers who use other factory than that OpenJPA uses. In that case configuration parameters are set in persistence.xml file instead of opencms.properties
file.
