### PR TITLE
Update src/org/opencms/workplace/commons/CmsPropertyCustom.java

### DIFF
--- a/src/org/opencms/workplace/commons/CmsPropertyCustom.java
+++ b/src/org/opencms/workplace/commons/CmsPropertyCustom.java
@@ -140,7 +140,7 @@ public class CmsPropertyCustom extends CmsPropertyAdvanced {
         // create the column heads
         result.append("<table border=\"0\">\n");
         result.append("<tr>\n");
-        result.append("\t<td class=\"textbold\">");
+        result.append("\t<td class=\"textbold\" nowrap>");
         result.append(key(Messages.GUI_PROPERTY_0));
         result.append("</td>\n");
         result.append("\t<td class=\"textbold\">");


### PR DESCRIPTION
Add a  nowrap to a td in property edit form. When localized in Chinese, one English word needs 2 or more square chars to match. The nowrap can make these chars stay in one line.
