### PR TITLE
CmsJspActionElement link(java.util.String, java.util.String) method does not do anything with the second parameter

### DIFF
--- a/src/org/opencms/jsp/CmsJspActionElement.java
+++ b/src/org/opencms/jsp/CmsJspActionElement.java
@@ -753,7 +753,7 @@ public class CmsJspActionElement extends CmsJspBean {
             return getMessage(NOT_INITIALIZED);
         }
         try {
-            return CmsJspTagLink.linkTagAction(target, getRequest());
+            return CmsJspTagLink.linkTagAction(target, getRequest(), detailPage);
         } catch (Throwable t) {
             handleException(t);
         }


### PR DESCRIPTION
Correction for http://bugzilla.opencms.org/show_bug.cgi?id=2021.

The method in org.opencms.jsp.CmsJspActionElement whose signature is
link(java.util.String target, java.util.String detailPage) doesn't do anything
with the second parameter, so the method is not doing what javadoc describes. I
guess the line "return CmsJspTagLink.linkTagAction(target, getRequest());"
should be "return CmsJspTagLink.linkTagAction(target, getRequest(),
detailPage);"
