### PR TITLE
build.xml: Task openjpac missing dependencies

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -152,16 +152,16 @@
 			<!-- compilerarg value="-Xlint:unchecked"/ -->
 		</javac>
 
-		<taskdef name="openjpac" classname="org.apache.openjpa.ant.PCEnhancerTask">
-			<classpath>
-				<fileset dir="${opencms.input.libs.compile}">
-					<include name="**/*.jar" />
-				</fileset>
-				<fileset dir="${opencms.input.libs.runtime}">
-					<include name="**/*.jar" />
-				</fileset>
-			</classpath>
-		</taskdef>
+		<path id="opencms.input.libs.all">
+			<fileset dir="${opencms.input.libs.compile}">
+				<include name="**/*.jar" />
+			</fileset>
+			<fileset dir="${opencms.input.libs.runtime}">
+				<include name="**/*.jar" />
+			</fileset>
+		</path>
+
+		<taskdef name="openjpac" classname="org.apache.openjpa.ant.PCEnhancerTask" classpathref="opencms.input.libs.all" />
 
 		<!-- invoke OpenJPA enhancer on all .class files below the persistence directory -->
 		<if>
@@ -175,6 +175,7 @@
 					</fileset>
 					<classpath>
 						<pathelement location="${opencms.output.classes}" />
+						<path refid="opencms.input.libs.all" />
 					</classpath>
 					<config propertiesFile="${opencms.input}/webapp/WEB-INF/classes/META-INF/persistence.xml" />
 				</openjpac>


### PR DESCRIPTION
The execution of the target `compile` invokes OpenJPA if `${enhance}=1` (default!), but the invocation is missing libraries:

``` xml
    <path id="opencms.input.libs.all">
        <fileset dir="${opencms.input.libs.compile}">
            <include name="**/*.jar" />
        </fileset>
        <fileset dir="${opencms.input.libs.runtime}">
            <include name="**/*.jar" />
        </fileset>
    </path>

    <openjpac>
        <fileset dir="${opencms.output.classes}/org/opencms/db/jpa/persistence">
            <include name="*.class" />
            <exclude name="*$*.class" />
        </fileset>
        <classpath>
            <pathelement location="${opencms.output.classes}" />
            <path refid="opencms.input.libs.all" /> <!-- This is missing! -->
        </classpath>
        <config propertiesFile="${opencms.input}/webapp/WEB-INF/classes/META-INF/persistence.xml" />
    </openjpac>
```
