### PR TITLE
Possible XSS Exploit fix

### DIFF
--- a/src/org/opencms/flex/Messages.java
+++ b/src/org/opencms/flex/Messages.java
@@ -65,6 +65,9 @@ public final class Messages extends A_CmsMessageBundle {
     public static final String ERR_HEADER_IFMODIFIEDSINCE_FORMAT_3 = "ERR_HEADER_IFMODIFIEDSINCE_FORMAT_3";
 
     /** Message constant for key in the resource bundle. */
+    public static final String ERR_FLEXRESPONSE_URI_SYNTAX_EXCEPTION_0 = "ERR_FLEXRESPONSE_URI_SYNTAX_EXCEPTION_0";
+
+    /** Message constant for key in the resource bundle. */
     public static final String INIT_FLEXCACHE_CREATED_2 = "INIT_FLEXCACHE_CREATED_2";
 
     /** Static instance member. */

--- a/src/org/opencms/flex/messages.properties
+++ b/src/org/opencms/flex/messages.properties
@@ -6,7 +6,7 @@ ERR_FLEXREQUESTDISPATCHER_ERROR_LOADING_RESOURCE_FROM_CACHE_1           =Error l
 ERR_FLEXREQUESTDISPATCHER_ERROR_READING_RESOURCE_1                      =Error reading VFS target resource "{0}".
 ERR_FLEXREQUESTDISPATCHER_INCLUSION_LOOP_1                              =VFS target resource "{0}" was already included earlier.
 ERR_FLEXREQUESTDISPATCHER_VFS_ACCESS_EXCEPTION_0                        =OpenCms VFS access exception.
-
+ERR_FLEXRESPONSE_URI_SYNTAX_EXCEPTION_0                                 =Possible XSS exploit detected, not sending redirect to response object.
 INIT_FLEXCACHE_CREATED_2                                                =. Flex cache           : Initializing with parameters enabled={0} cacheOffline={1}
 INIT_FLEXCACHE_DEVICE_SELECTOR_FAILURE_1                                =. Device selector      : {0} could not be instanciated
 INIT_FLEXCACHE_DEVICE_SELECTOR_SUCCESS_1                                =. Device selector      : {0} instanciated

--- a/src/org/opencms/util/CmsRequestUtil.java
+++ b/src/org/opencms/util/CmsRequestUtil.java
@@ -725,8 +725,14 @@ public final class CmsRequestUtil {
         jsp.getRequest().setAttribute(
             CmsRequestUtil.ATTRIBUTE_ERRORCODE,
             new Integer(HttpServletResponse.SC_MOVED_PERMANENTLY));
-        jsp.getResponse().setHeader(HEADER_LOCATION, newTarget);
         jsp.getResponse().setHeader(HEADER_CONNECTION, "close");
+        try {
+            jsp.getResponse().sendRedirect(newTarget);
+        } catch (IOException e) {
+            LOG.error(Messages.get().getBundle().key(Messages.ERR_IOERROR_0), e);
+            // In case of an IOException, we send the redirect ourselves
+            jsp.getResponse().setHeader(HEADER_LOCATION, newTarget);
+        }
     }
 
     /**


### PR DESCRIPTION
Pages using CmsRequestUtil.redirectPermanently() or CmsFlexResponse.sendRedirect() with unfiltered parameters can abuse this XSS exploit (HTTP header injection).

See https://en.wikipedia.org/wiki/HTTP_header_injection
