### PR TITLE
Fixing attributes handling in CmsFlexCacheKey

### DIFF
--- a/src/org/opencms/flex/CmsFlexCacheKey.java
+++ b/src/org/opencms/flex/CmsFlexCacheKey.java
@@ -443,7 +443,11 @@ public class CmsFlexCacheKey {
                             str.append(s);
                             str.append("=");
                             Object value = keyAttrs.get(s);
-                            str.append(value.toString());
+                            if (value != null) {
+                                str.append(value.toString());
+                            } else {
+                                str.append(String.valueOf((Object)null));
+                            }
                             if (i.hasNext()) {
                                 str.append(",");
                             }


### PR DESCRIPTION
If attribute, which is used as part flex cache key is null, we get error, when trying to build flex cache key. It's wrong, because null can be valid value for such situation and we have to handle it
