### PR TITLE
When going to workplace preferences section, there's a "Start with view" dropdown list.

### DIFF
--- a/src/org/opencms/workplace/commons/CmsPreferences.java
+++ b/src/org/opencms/workplace/commons/CmsPreferences.java
@@ -955,7 +955,7 @@ public class CmsPreferences extends CmsTabDialog {
 
         // loop through the vectors and fill the result vectors
         List<CmsWorkplaceView> list = new ArrayList<CmsWorkplaceView>(OpenCms.getWorkplaceManager().getViews());
-        CmsWorkplaceView directEditView = new CmsWorkplaceView(Messages.get().getBundle().key(
+        CmsWorkplaceView directEditView = new CmsWorkplaceView(Messages.get().getBundle(getLocale()).key(
             Messages.GUI_LABEL_DIRECT_EDIT_VIEW_0), CmsWorkplace.VIEW_DIRECT_EDIT, Float.valueOf(100));
         list.add(directEditView);
 


### PR DESCRIPTION
When going to workplace preferences section, there's a "Start with view" dropdown list. The "Direct Edit" item inside this dropdown does not respond to language setting changes. 
If I change it to Russian or German for example, it still says "Direct Edit" in English (or whatever the default language is set to).

If the default language is set to German, then it'll stay in German despite what I choose in the "Startup Settings -> Language" dropdown.
