### PR TITLE
Fixed a bug in the file history function in which an unlimited setting would prevent all but the latest version from being saved.

### DIFF
--- a/src/org/opencms/db/generic/CmsHistoryDriver.java
+++ b/src/org/opencms/db/generic/CmsHistoryDriver.java
@@ -172,8 +172,8 @@ public class CmsHistoryDriver implements I_CmsDriver, I_CmsHistoryDriver {
                     }
                 }
             }
-
-            if ((maxVersion - versionsToKeep) <= 0) {
+            // versionsToKeep < 0 is the same as unlimited so do not delete
+            if (versionsToKeep < 0 || (maxVersion - versionsToKeep) <= 0) {
                 // nothing to delete
                 internalCleanup(dbc, resource);
                 return 0;


### PR DESCRIPTION
If the file version history setting is set to unlimited then it will not save the previous versions to the database when it is published. The result is that only the latest version is saved.  The fix is to check if the versionsToKeep is less than zero. (The setting is -1 if it is unlimited)