### PR TITLE
Fix for Time Warp Feature (viewing resources with future dates)

### DIFF
--- a/src/org/opencms/ade/containerpage/CmsElementUtil.java
+++ b/src/org/opencms/ade/containerpage/CmsElementUtil.java
@@ -54,6 +54,7 @@ import org.opencms.main.OpenCms;
 import org.opencms.search.galleries.CmsGallerySearch;
 import org.opencms.search.galleries.CmsGallerySearchResult;
 import org.opencms.security.CmsPermissionSet;
+import org.opencms.util.CmsRequestUtil;
 import org.opencms.util.CmsStringUtil;
 import org.opencms.util.CmsUUID;
 import org.opencms.workplace.CmsWorkplaceMessages;
@@ -161,6 +162,9 @@ public class CmsElementUtil {
         m_res = res;
         m_currentPageUri = currentPageUri;
         m_locale = locale;
+
+        CmsRequestUtil.warpRequestTime(m_cms, req);
+        
         // initializing request for standard context bean
         req.setAttribute(CmsJspStandardContextBean.ATTRIBUTE_CMS_OBJECT, m_cms);
         if (detailContentId != null) {

--- a/src/org/opencms/i18n/CmsDefaultLocaleHandler.java
+++ b/src/org/opencms/i18n/CmsDefaultLocaleHandler.java
@@ -44,6 +44,7 @@ import java.util.Locale;
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.logging.Log;
+import org.opencms.util.CmsRequestUtil;
 
 /**
  * Default implementation of the locale handler.<p>
@@ -88,7 +89,8 @@ public class CmsDefaultLocaleHandler implements I_CmsLocaleHandler {
             // must switch project id in stored Admin context to match current project
             adminCms.getRequestContext().setCurrentProject(project);
             adminCms.getRequestContext().setUri(resourceName);
-
+            CmsRequestUtil.warpRequestTime(adminCms, req);
+            
             // now get default m_locale names
             CmsResource res = null;
             try {

--- a/src/org/opencms/jsp/util/CmsJspStandardContextBean.java
+++ b/src/org/opencms/jsp/util/CmsJspStandardContextBean.java
@@ -48,6 +48,7 @@ import org.opencms.main.CmsLog;
 import org.opencms.main.CmsRuntimeException;
 import org.opencms.main.OpenCms;
 import org.opencms.util.CmsCollectionsGenericWrapper;
+import org.opencms.util.CmsRequestUtil;
 import org.opencms.util.CmsStringUtil;
 import org.opencms.util.CmsUUID;
 import org.opencms.xml.containerpage.CmsContainerBean;
@@ -65,6 +66,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.collections.Transformer;
 import org.apache.commons.logging.Log;
@@ -769,6 +771,10 @@ public final class CmsJspStandardContextBean {
         } catch (CmsException e) {
             // should not happen
             m_cms = cms;
+        }
+
+        if(m_request instanceof HttpServletRequest) {
+            CmsRequestUtil.warpRequestTime(m_cms, (HttpServletRequest) m_request);
         }
     }
 

--- a/src/org/opencms/util/CmsRequestUtil.java
+++ b/src/org/opencms/util/CmsRequestUtil.java
@@ -27,12 +27,14 @@
 
 package org.opencms.util;
 
+import org.opencms.file.CmsObject;
 import org.opencms.flex.CmsFlexRequest;
 import org.opencms.i18n.CmsEncoder;
 import org.opencms.json.JSONArray;
 import org.opencms.json.JSONException;
 import org.opencms.json.JSONObject;
 import org.opencms.jsp.CmsJspActionElement;
+import org.opencms.main.CmsContextInfo;
 import org.opencms.main.CmsLog;
 import org.opencms.main.OpenCms;
 
@@ -838,5 +840,24 @@ public final class CmsRequestUtil {
 
         HttpSession session = request.getSession(true);
         session.setAttribute(key, value);
+    }
+
+    /**
+     * Sets the request context's request time to the warp time the user has specified.<p>
+     *
+     * If the user has not specified a warp time, the request time is not modified.<p>
+     *
+     * @param cms the cms context
+     * @param request the http request
+     */
+    public static void warpRequestTime(CmsObject cms, HttpServletRequest request) {
+
+        if(!cms.getRequestContext().getCurrentProject().isOnlineProject()) {
+            Long timeWarpValue = (Long) getSessionValue(request, CmsContextInfo.ATTRIBUTE_REQUEST_TIME);
+
+            if (timeWarpValue != null) {
+                cms.getRequestContext().setRequestTime(timeWarpValue);
+            }
+        }
     }
 }


### PR DESCRIPTION
The time warp feature didn't appear to be fully functional. The primary issue being that the request time of the request context was never being set to the specified warp time. Therefore it never simulated a future date, thus any resources with a future date were being rejected.

I found an existing issue opened by Areks here:
https://github.com/alkacon/opencms-core/issues/199

The proposed solution unfortunately didn't work for me, but we're attempting to fix the same issue.

The two issues that are addressed with this update:
1) If a warp time is set by the user, set the request time to it (see CmsElementUtil.java) so that pages with a future release date can be displayed in offline mode instead of throwing a CmsVfsResourceNotFoundException.
2) The change above fixes the container pages, but a change is also needed for Solr queries (if Solr is being used in a page). For example, if a warp time is set, the filter query "released:[* TO NOW]" doesn't reflect the warp time. "NOW" should be replaced with the warp time, since the purpose of the warp time feature is to simulate how the page would react for a future date.