### PR TITLE
Fixed issue where "Keep permissions" setting was being ignored when importing files in Database Management

### DIFF
--- a/src-modules/org/opencms/workplace/tools/database/CmsDatabaseImportFromHttp.java
+++ b/src-modules/org/opencms/workplace/tools/database/CmsDatabaseImportFromHttp.java
@@ -95,7 +95,7 @@ public class CmsDatabaseImportFromHttp extends A_CmsImportFromHttp {
         }
         Map params = new HashMap();
         params.put(PARAM_FILE, getParamImportfile());
-        params.put(PARAM_KEEPPERMISSIONS, getParamKeepPermissions());
+        params.put(PARAM_KEEPPERMISSIONS.toLowerCase(), getParamKeepPermissions());
         // set style to display report in correct layout
         params.put(PARAM_STYLE, CmsToolDialog.STYLE_NEW);
         // set close link to get back to overview after finishing the import

--- a/src-modules/org/opencms/workplace/tools/database/CmsDatabaseImportFromHttp.java
+++ b/src-modules/org/opencms/workplace/tools/database/CmsDatabaseImportFromHttp.java
@@ -95,7 +95,7 @@ public class CmsDatabaseImportFromHttp extends A_CmsImportFromHttp {
         }
         Map params = new HashMap();
         params.put(PARAM_FILE, getParamImportfile());
-        params.put(PARAM_KEEPPERMISSIONS, getParamKeeppermissions());
+        params.put(PARAM_KEEPPERMISSIONS, getParamKeepPermissions());
         // set style to display report in correct layout
         params.put(PARAM_STYLE, CmsToolDialog.STYLE_NEW);
         // set close link to get back to overview after finishing the import
@@ -125,7 +125,7 @@ public class CmsDatabaseImportFromHttp extends A_CmsImportFromHttp {
      *
      * @return the keepPermissions parameter
      */
-    public String getParamKeeppermissions() {
+    public String getParamKeepPermissions() {
 
         return m_keepPermissions;
     }
@@ -143,7 +143,7 @@ public class CmsDatabaseImportFromHttp extends A_CmsImportFromHttp {
      *
      * @param keepPermissions the keepPermissions parameter
      */
-    public void setParamKeeppermissions(String keepPermissions) {
+    public void setParamKeepPermissions(String keepPermissions) {
 
         m_keepPermissions = keepPermissions;
     }

--- a/src-modules/org/opencms/workplace/tools/database/CmsDatabaseImportFromServer.java
+++ b/src-modules/org/opencms/workplace/tools/database/CmsDatabaseImportFromServer.java
@@ -150,7 +150,7 @@ public class CmsDatabaseImportFromServer extends CmsWidgetDialog {
 
         Map params = new HashMap();
         params.put(PARAM_FILE, getImportFile());
-        params.put(PARAM_KEEPPERMISSIONS, getKeepPermissions());
+        params.put(PARAM_KEEPPERMISSIONS.toLowerCase(), getKeepPermissions());
         // set style to display report in correct layout
         params.put(PARAM_STYLE, CmsToolDialog.STYLE_NEW);
         // set close link to get back to overview after finishing the import


### PR DESCRIPTION
The "Keep permissions" setting in *Administration View > Database Management > Import File from Server* was being ignored. When "Keep permissions" is checked, the permission set on existing resources is not supposed to be modified. However, currently, whether or not the setting is checked, the permission set is being modified. This patch addresses that issue.