### PR TITLE
When the clone module app is copying the resource type no check if exist...

### DIFF
--- a/src-modules/org/opencms/workplace/tools/modules/CmsCloneModuleThread.java
+++ b/src-modules/org/opencms/workplace/tools/modules/CmsCloneModuleThread.java
@@ -491,7 +491,7 @@ public class CmsCloneModuleThread extends A_CmsReportThread {
         for (Map.Entry<String, String> entry : iconPaths.entrySet()) {
             String source = ICON_PATH + entry.getKey();
             String target = ICON_PATH + entry.getValue();
-            if (!getCms().existsResource(target)) {
+            if (getCms().existsResource(source) && !getCms().existsResource(target)) {
                 getCms().copyResource(source, target);
             }
         }


### PR DESCRIPTION
When the clone module app is copying the resource type no check if exists the source (ICON_PATH + entry.getKey()). When the resource doesn't exist, the proccess stops.