### PR TITLE
Preserve formatter config settings order

### DIFF
--- a/src/org/opencms/ade/configuration/formatters/CmsFormatterBeanParser.java
+++ b/src/org/opencms/ade/configuration/formatters/CmsFormatterBeanParser.java
@@ -48,6 +48,7 @@ import org.opencms.xml.types.I_CmsXmlContentValue;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -191,7 +192,7 @@ public class CmsFormatterBeanParser {
     private String m_resourceType;
 
     /** Parsed field. */
-    private Map<String, CmsXmlContentProperty> m_settings = new HashMap<String, CmsXmlContentProperty>();
+    private Map<String, CmsXmlContentProperty> m_settings = new LinkedHashMap<String, CmsXmlContentProperty>();
 
     /**
      * Creates a new parser instance.<p>


### PR DESCRIPTION
When editing a formatter config file and switching to the **Supported settings** tab, there's a list of settings. These settings can be re-ordered in the UI with the _move up_ and _move down_ buttons. But when it comes time to display these settings in the ADE (element settings), they show up in a random order (or more precisely, their order looks random because it's based on hashCode() since HashMap is being used).

By changing the underlying data structure to LinkedHashMap, the insertion order is preserved, and it follows the order defined in the formatter config file. This allows the user to re-order the settings any which way they like.
