### PR TITLE
Workaround mangled javadocs (java 8+)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,6 +176,7 @@ task javadocComponents(type: Javadoc, dependsOn: componentsJar) {
     source = sourceSets.components.allJava
     classpath = project.sourceSets.components.compileClasspath
     destinationDir = file("${buildDir}/docs/javadocComponents")
+    failOnError = false
 }
 
 task javadocJarComponents(type: Jar, dependsOn: javadocComponents) {
@@ -253,6 +254,8 @@ javadoc {
         stylesheetFile= file("${projectDir}/doc/javadoc/stylesheet.css")
         header = "<script type=\"text/javascript\"> if (window.location.href.indexOf(\"overview-frame\") == -1) { document.write(\"<a id=\\\"brandingLink\\\" target=\\\"_blank\\\" href=\\\"http://www.alkacon.com\\\"><img border=\\\"0\\\" id=\\\"brandingPic\\\" src=\\\"{@docRoot}/logos/Alkacon.png\\\" /></a>\"); } else { document.write(\"<a id=\\\"brandingLink\\\" target=\\\"_blank\\\" href=\\\"http://www.opencms.com\\\"><img border=\\\"0\\\" id=\\\"brandingPic\\\" src=\\\"{@docRoot}/logos/OpenCms.png\\\" /></a>\"); }</script>"
     }
+
+    failOnError = false
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
@@ -312,6 +315,7 @@ task javadocModules(type: Javadoc, dependsOn: jar) {
     source = sourceSets.modules.allJava
     classpath = project.sourceSets.modules.compileClasspath
     destinationDir = file("${buildDir}/docs/javadocModules")
+    failOnError = false
 }
 
 task javadocGwt(type: Javadoc, dependsOn: jar) {
@@ -339,6 +343,7 @@ task javadocGwt(type: Javadoc, dependsOn: jar) {
     source = sourceSets.gwt.allJava
     classpath = project.sourceSets.gwt.compileClasspath
     destinationDir = file("${buildDir}/docs/javadocGwt")
+    failOnError = false
 }
 
 task javadocJarGwt(type: Jar, dependsOn: javadocGwt) {
@@ -397,6 +402,8 @@ task javadocSetup(type: Javadoc, dependsOn: jar) {
         stylesheetFile= file("${projectDir}/doc/javadoc/stylesheet.css")
         header = "<script type=\"text/javascript\"> if (window.location.href.indexOf(\"overview-frame\") == -1) { document.write(\"<a id=\\\"brandingLink\\\" target=\\\"_blank\\\" href=\\\"http://www.alkacon.com\\\"><img border=\\\"0\\\" id=\\\"brandingPic\\\" src=\\\"{@docRoot}/logos/Alkacon.png\\\" /></a>\"); } else { document.write(\"<a id=\\\"brandingLink\\\" target=\\\"_blank\\\" href=\\\"http://www.opencms.com\\\"><img border=\\\"0\\\" id=\\\"brandingPic\\\" src=\\\"{@docRoot}/logos/OpenCms.png\\\" /></a>\"); }</script>"
     }
+
+    failOnError = false
 }
 
 task javadocJarSetup(type: Jar, dependsOn: javadocSetup) {
@@ -575,6 +582,7 @@ allModuleNames.split(',').each{ moduleName ->
             source = sourceSets[moduleName].allJava
             classpath = project.sourceSets[moduleName].compileClasspath
             destinationDir = file("${buildDir}/docs/javadoc${moduleName}")
+            failOnError = false
             
         }
 
@@ -917,6 +925,7 @@ task javadocTest(type: Javadoc, dependsOn: jar) {
     source = sourceSets.test.allJava
     classpath = project.sourceSets.test.compileClasspath
     destinationDir = file("${buildDir}/docs/javadocTest")
+    failOnError = false
 }
 
 task javadocJarTest(type: Jar, dependsOn: javadocTest) {
@@ -1354,9 +1363,3 @@ tasks.withType(JavaCompile) {
 tasks.withType(Javadoc) {
     options.addStringOption("sourcepath", "")
 }
-
-
-        
-
-
-

--- a/build.gradle
+++ b/build.gradle
@@ -176,7 +176,6 @@ task javadocComponents(type: Javadoc, dependsOn: componentsJar) {
     source = sourceSets.components.allJava
     classpath = project.sourceSets.components.compileClasspath
     destinationDir = file("${buildDir}/docs/javadocComponents")
-    failOnError = false
 }
 
 task javadocJarComponents(type: Jar, dependsOn: javadocComponents) {
@@ -254,8 +253,6 @@ javadoc {
         stylesheetFile= file("${projectDir}/doc/javadoc/stylesheet.css")
         header = "<script type=\"text/javascript\"> if (window.location.href.indexOf(\"overview-frame\") == -1) { document.write(\"<a id=\\\"brandingLink\\\" target=\\\"_blank\\\" href=\\\"http://www.alkacon.com\\\"><img border=\\\"0\\\" id=\\\"brandingPic\\\" src=\\\"{@docRoot}/logos/Alkacon.png\\\" /></a>\"); } else { document.write(\"<a id=\\\"brandingLink\\\" target=\\\"_blank\\\" href=\\\"http://www.opencms.com\\\"><img border=\\\"0\\\" id=\\\"brandingPic\\\" src=\\\"{@docRoot}/logos/OpenCms.png\\\" /></a>\"); }</script>"
     }
-
-    failOnError = false
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
@@ -315,7 +312,6 @@ task javadocModules(type: Javadoc, dependsOn: jar) {
     source = sourceSets.modules.allJava
     classpath = project.sourceSets.modules.compileClasspath
     destinationDir = file("${buildDir}/docs/javadocModules")
-    failOnError = false
 }
 
 task javadocGwt(type: Javadoc, dependsOn: jar) {
@@ -343,7 +339,6 @@ task javadocGwt(type: Javadoc, dependsOn: jar) {
     source = sourceSets.gwt.allJava
     classpath = project.sourceSets.gwt.compileClasspath
     destinationDir = file("${buildDir}/docs/javadocGwt")
-    failOnError = false
 }
 
 task javadocJarGwt(type: Jar, dependsOn: javadocGwt) {
@@ -402,8 +397,6 @@ task javadocSetup(type: Javadoc, dependsOn: jar) {
         stylesheetFile= file("${projectDir}/doc/javadoc/stylesheet.css")
         header = "<script type=\"text/javascript\"> if (window.location.href.indexOf(\"overview-frame\") == -1) { document.write(\"<a id=\\\"brandingLink\\\" target=\\\"_blank\\\" href=\\\"http://www.alkacon.com\\\"><img border=\\\"0\\\" id=\\\"brandingPic\\\" src=\\\"{@docRoot}/logos/Alkacon.png\\\" /></a>\"); } else { document.write(\"<a id=\\\"brandingLink\\\" target=\\\"_blank\\\" href=\\\"http://www.opencms.com\\\"><img border=\\\"0\\\" id=\\\"brandingPic\\\" src=\\\"{@docRoot}/logos/OpenCms.png\\\" /></a>\"); }</script>"
     }
-
-    failOnError = false
 }
 
 task javadocJarSetup(type: Jar, dependsOn: javadocSetup) {
@@ -582,7 +575,6 @@ allModuleNames.split(',').each{ moduleName ->
             source = sourceSets[moduleName].allJava
             classpath = project.sourceSets[moduleName].compileClasspath
             destinationDir = file("${buildDir}/docs/javadoc${moduleName}")
-            failOnError = false
             
         }
 
@@ -925,7 +917,6 @@ task javadocTest(type: Javadoc, dependsOn: jar) {
     source = sourceSets.test.allJava
     classpath = project.sourceSets.test.compileClasspath
     destinationDir = file("${buildDir}/docs/javadocTest")
-    failOnError = false
 }
 
 task javadocJarTest(type: Jar, dependsOn: javadocTest) {
@@ -1362,4 +1353,12 @@ tasks.withType(JavaCompile) {
 }
 tasks.withType(Javadoc) {
     options.addStringOption("sourcepath", "")
+}
+
+if (JavaVersion.current().isJava8Compatible()) {
+    allprojects {
+        tasks.withType(Javadoc) {
+            failOnError = false
+       }
+    }
 }


### PR DESCRIPTION
With Java 8+, the build fails when executing <tt>gradle install</tt> with the following message:

    [...]
    100 errors
    100 warnings
    :javadoc FAILED
    
    FAILURE: Build failed with an exception.
    
    * What went wrong:
    Execution failed for task ':javadoc'.
    [...]

In my opinion, the javadocs are too mangled to try to fix them. This workaround allows the build to ignore javadoc errors when installing artifacts.