### PR TITLE
setup.sh: Fix ArrayIndexOutOfBoundsException / NPE

### DIFF
--- a/src-setup/org/opencms/setup/CmsAutoSetup.java
+++ b/src-setup/org/opencms/setup/CmsAutoSetup.java
@@ -89,7 +89,7 @@ public class CmsAutoSetup {
 
         String path = null;
 
-        if ((args[0] != null) && args[0].startsWith(PARAM_CONFIG_PATH)) {
+        if ((args.length>0) && (args[0] != null) && args[0].startsWith(PARAM_CONFIG_PATH)) {
             if ((args.length == 2) && (args[1] != null) && new File(args[1]).exists()) {
                 path = args[1];
             } else {
@@ -97,7 +97,7 @@ public class CmsAutoSetup {
             }
         }
 
-        if (new File(path).exists()) {
+        if ((null != path) && (new File(path).exists())) {
             System.out.println("Using config file: " + path + ":");
             try {
                 CmsAutoSetupProperties props = new CmsAutoSetupProperties(path);


### PR DESCRIPTION
`WEBINF/setup.sh` without parameters ends abruptly without printing any help message. See output:

```
23427:  Admin@Offline>exit
23428:  
23429:  
23430:  The setup is finished!
23431:  The OpenCms system used for the setup will now shut down.
23432:  
23433:  
23434:  Shutting down OpenCms, version 9.5.x in web application "opencms"
23435:  Shutdown completed, total uptime was 00:05:17.
23436:  

-------------------------------------------------
Setup started at: (Mon Oct 06 10:01:58 CEST 2014)
-------------------------------------------------

Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: 0
    at org.opencms.setup.CmsAutoSetup.main(CmsAutoSetup.java:92)
```

`WEB-INF/setup.sh -help` or `WEB-INF/setup.sh --help` also breaks with a NPE:

```
23427:  Admin@Offline>exit
23428:  
23429:  
23430:  The setup is finished!
23431:  The OpenCms system used for the setup will now shut down.
23432:  
23433:  
23434:  Shutting down OpenCms, version 9.5.x in web application "opencms"
23435:  Shutdown completed, total uptime was 00:05:17.
23436:  

-------------------------------------------------
Setup started at: (Mon Oct 06 10:04:18 CEST 2014)
-------------------------------------------------

Exception in thread "main" java.lang.NullPointerException
    at java.io.File.<init>(File.java:277)
    at org.opencms.setup.CmsAutoSetup.main(CmsAutoSetup.java:100)
```
