### PR TITLE
Fixed cmsshell.sh so that running the cms shell outside of WEB-INF is possible

### DIFF
--- a/webapp/WEB-INF/cmsshell.sh
+++ b/webapp/WEB-INF/cmsshell.sh
@@ -33,5 +33,5 @@ for JAR in ${OPENCMS_BASE}/lib/*.jar; do
    OPENCMS_CLASSPATH="${OPENCMS_CLASSPATH}:${JAR}"
 done
 
-java -classpath "${OPENCMS_CLASSPATH}:${TOMCAT_CLASSPATH}:classes" org.opencms.main.CmsShell -base="${OPENCMS_BASE}" "$@"
+java -classpath "${OPENCMS_CLASSPATH}:${TOMCAT_CLASSPATH}:${OPENCMS_BASE}/classes" org.opencms.main.CmsShell -base="${OPENCMS_BASE}" "$@"
 


### PR DESCRIPTION
Running the cms shell was only possible when the working directory was [webapp-basepath]/WEB-INF, because the classpath contained the relative directory "classes".
This was fixed by adding "${OPENCMS_BASE}/" before classes.
