### PR TITLE
Fix for issue #296 (Content-Definition with XSD: Wrong order for choice elements after XSD change or saving in control code editor)

### DIFF
--- a/src/org/opencms/xml/A_CmsXmlDocument.java
+++ b/src/org/opencms/xml/A_CmsXmlDocument.java
@@ -284,39 +284,22 @@ public abstract class A_CmsXmlDocument implements I_CmsXmlDocument {
 
                         // step 1: first sort the nodes according to the schema, this takes care of re-ordered elements
                         List<List<Element>> nodeLists = new ArrayList<List<Element>>();
-                        for (I_CmsXmlSchemaType type : cd.getTypeSequence()) {
-                            List<Element> elements = CmsXmlGenericWrapper.elements(root, type.getName());
-                            int maxOccures = cd.getChoiceMaxOccurs() > 0
-                            ? cd.getChoiceMaxOccurs()
-                            : type.getMaxOccurs();
-                            if (elements.size() > maxOccures) {
-                                if (type.getTypeName().equals(CmsXmlCategoryValue.TYPE_NAME)) {
-                                    if (type.getMaxOccurs() == 1) {
-                                        Element category = elements.get(0);
-                                        List<Element> categories = new ArrayList<Element>();
-                                        for (Element value : elements) {
-                                            @SuppressWarnings("unchecked")
-                                            Iterator<Element> itLink = value.elementIterator();
-                                            while (itLink.hasNext()) {
-                                                Element link = itLink.next();
-                                                categories.add((Element)link.clone());
-                                            }
-                                        }
-                                        category.clearContent();
-                                        for (Element value : categories) {
-                                            category.add(value);
-                                        }
-                                    }
+                        boolean isMultipleChoice = cd.getSequenceType() == CmsXmlContentDefinition.SequenceType.MULTIPLE_CHOICE;
 
-                                }
-
-                                // to many nodes of this type appear according to the current schema definition
-                                for (int lo = (elements.size() - 1); lo >= type.getMaxOccurs(); lo--) {
-                                    elements.remove(lo);
-                                }
-
-                            }
+                        // if it's a multiple choice element, the child elements must not be sorted into their types,
+                        // but must keep their original order
+                        if (isMultipleChoice) {
+                            List<Element> elements = CmsXmlGenericWrapper.elements(root);
+                            checkMaxOccurs(elements, cd.getChoiceMaxOccurs(), cd.getTypeName());
                             nodeLists.add(elements);
+                        }
+                        // if it's a sequence, the children are sorted according to the sequence type definition
+                        else {
+                            for (I_CmsXmlSchemaType type : cd.getTypeSequence()) {
+                                List<Element> elements = CmsXmlGenericWrapper.elements(root, type.getName());
+                                checkMaxOccurs(elements, type.getMaxOccurs(), type.getTypeName());
+                                nodeLists.add(elements);
+                            }
                         }
 
                         // step 2: clear the list of nodes (this will remove all invalid nodes)
@@ -343,6 +326,40 @@ public abstract class A_CmsXmlDocument implements I_CmsXmlDocument {
             m_file.setContents(marshal());
         }
         return m_file;
+    }
+
+    /**
+     * Removes all nodes that exceed newly defined maxOccurs rules from the list of elements
+     * @param cd the content type definition
+     * @param maxOccurs maximum number of elements allowed
+     * @param typeName name of the element type
+     */
+    private void checkMaxOccurs(List<Element> elements, int maxOccurs, String typeName) {
+        if (elements.size() > maxOccurs) {
+            if (typeName.equals(CmsXmlCategoryValue.TYPE_NAME)) {
+                if (maxOccurs == 1) {
+                    Element category = elements.get(0);
+                    List<Element> categories = new ArrayList<Element>();
+                    for (Element value : elements) {
+                        @SuppressWarnings("unchecked")
+                        Iterator<Element> itLink = value.elementIterator();
+                        while (itLink.hasNext()) {
+                            Element link = itLink.next();
+                            categories.add((Element)link.clone());
+                        }
+                    }
+                    category.clearContent();
+                    for (Element value : categories) {
+                        category.add(value);
+                    }
+                }
+            }
+        
+            // too many nodes of this type appear according to the current schema definition
+            for (int lo = (elements.size() - 1); lo >= maxOccurs; lo--) {
+                elements.remove(lo);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This commit fixes issue #296 by adding a different behaviour for SequenceType.MULTIPLE_CHOICE. For multiple choice elements the child elements are not ordered according to their respective types, but are kept in the original order, no matter what type they are.