### PR TITLE
Provide support for configuring a jdbc connection with Properties

### DIFF
--- a/src/org/opencms/configuration/CmsParameterConfiguration.java
+++ b/src/org/opencms/configuration/CmsParameterConfiguration.java
@@ -43,6 +43,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.TreeMap;
@@ -827,5 +828,47 @@ public class CmsParameterConfiguration extends AbstractMap<String, String> {
             m_configurationObjects.put(key, value);
             m_configurationStrings.put(key, value);
         }
+    }
+    
+    /**
+     * Creates a new <tt>Properties</tt> object from the existing configuration
+     * extracting all key-value pars whose key are prefixed
+     * with <tt>keyPrefix</tt>. <p>
+     * 
+     * For this example config:
+     * 
+     * <pre>
+     *      # lines starting with # are comments
+     *      db.pool.default.jdbcDriver=net.bull.javamelody.JdbcDriver
+     *      db.pool.default.connectionProperties.driver=org.gjt.mm.mysql.Driver
+     * </pre>
+     * 
+     * <tt>getPrefixedProperties("db.pool.default.connectionProperties")</tt>
+     * will return a <tt>Properties</tt> object with one single entry:
+     * <pre>
+     *      key:"driver", value:"org.gjt.mm.mysql.Driver"
+     * </pre>
+     * 
+     * @param keyPrefix prefix to match. If it isn't already, it will be
+     *           terminated with a dot.  If <tt>null</tt>, it will return
+     *           an empty <tt>Properties</tt> instance
+     * @return a new <tt>Properties</tt> object with all the entries from this
+     *          configuration whose keys math the prefix
+     */
+    public Properties getPrefixedProperties(String keyPrefix) {
+        Properties props = new Properties();
+        if (null == keyPrefix) {
+            return props;
+        }
+        
+        String dotTerminatedKeyPrefix = keyPrefix + (keyPrefix.endsWith(".")?"":".");
+        for (Map.Entry<String,String> e: entrySet()) {
+            String key = e.getKey();
+            if (null != key && key.startsWith(dotTerminatedKeyPrefix)) {
+                String subKey = key.substring(dotTerminatedKeyPrefix.length());
+                props.put(subKey, e.getValue());
+            }
+        }
+        return props;
     }
 }

--- a/src/org/opencms/db/CmsDbPool.java
+++ b/src/org/opencms/db/CmsDbPool.java
@@ -85,6 +85,9 @@ public final class CmsDbPool {
     public static final String KEY_ENTITY_MANAGER_POOL_SIZE = "entityMangerPoolSize";
 
     /** Key for jdbc driver. */
+    public static final String KEY_CONNECTION_PROPERTIES = "connectionProperties";
+
+    /** Key for jdbc driver. */
     public static final String KEY_JDBC_DRIVER = "jdbcDriver";
 
     /** Key for jdbc url. */

--- a/src/org/opencms/db/CmsDbPool.java
+++ b/src/org/opencms/db/CmsDbPool.java
@@ -36,6 +36,7 @@ import org.opencms.util.CmsStringUtil;
 import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 
 import org.apache.commons.dbcp.ConnectionFactory;
 import org.apache.commons.dbcp.DriverManagerConnectionFactory;
@@ -297,7 +298,10 @@ public final class CmsDbPool {
             jdbcUrl += jdbcUrlParams;
         }
 
-        ConnectionFactory connectionFactory = new DriverManagerConnectionFactory(jdbcUrl, username, password);
+        Properties connectionProperties = config.getPrefixedProperties(KEY_DATABASE_POOL + '.' + key + '.' + KEY_CONNECTION_PROPERTIES);
+        connectionProperties.put(KEY_USERNAME, username);
+        connectionProperties.put(KEY_PASSWORD, password);
+        ConnectionFactory connectionFactory = new DriverManagerConnectionFactory(jdbcUrl, connectionProperties);
 
         // Set up statement pool, if desired
         GenericKeyedObjectPoolFactory statementFactory = null;

--- a/test/org/opencms/configuration/TestParameterConfiguration.java
+++ b/test/org/opencms/configuration/TestParameterConfiguration.java
@@ -32,6 +32,7 @@ import org.opencms.test.OpenCmsTestCase;
 import java.io.File;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.util.Properties;
 
 import org.apache.commons.collections.ExtendedProperties;
 
@@ -122,5 +123,34 @@ public class TestParameterConfiguration extends OpenCmsTestCase {
             assertTrue("Key '" + key + "' not found in CmsConfiguration", extProp.containsKey(key));
             assertTrue("Objects for '" + key + "' not equal", value.equals(extProp.getProperty(key)));
         }
+    }
+    
+    /**
+     * Tests the extraction of properties.
+     * 
+     * @throws Exception
+     */
+    public void testExtractionOfPrefixedConfiguration() throws Exception {
+
+        CmsParameterConfiguration config = new CmsParameterConfiguration();
+
+        config.add("a",    "value_a");
+        config.add("a.b1", "value_a.b1");
+        config.add("a.b2", "value_a.b2");
+        config.add("a.b1.c1", "value_a.b1.c1"); // These three will be retrieved
+        config.add("a.b1.c2", "value_a.b1.c2"); // These three will be retrieved
+        config.add("a.b1.c3", "value_a.b1.c3"); // These three will be retrieved
+        config.add("a.b2.c1", "value_a.b2.c1");
+        config.add("a.b2.c2", "value_a.b2.c2");
+        config.add("a.b2.c3", "value_a.b2.c3");
+        Properties result = config.getPrefixedProperties("a.b1");
+        assertNull("Key 'a' found in Properties", result.getProperty("a"));
+        assertNull("Key 'a.b1' found in Properties", result.getProperty("a.b1"));
+        assertNull("Key 'b1' found in Properties", result.getProperty("b1"));
+        assertNull("Empty key '' found in Properties", result.getProperty(""));
+        assertEquals("Incorrect value of key c1 (a.b1.c1)", "value_a.b1.c1", result.getProperty("c1"));
+        assertEquals("Incorrect value of key c2 (a.b1.c2)", "value_a.b1.c2", result.getProperty("c2"));
+        assertEquals("Incorrect value of key c2 (a.b1.c3)", "value_a.b1.c3", result.getProperty("c3"));
+        assertEquals("Incorrect number of properties", 3, result.size());
     }
 }


### PR DESCRIPTION
Currently, it is only possible to configure a jdbc connection by defining the jdbcUrl.params. Unfortunatelly, jdbc drivers implementations could ignore these parameters or could only support configuration during the connect invocation.
To configure a jdbc connection, use connectionProperties.*. For example, if you want JavaMelody to analyze jdbc connections:
    db.pool.default.connectionProperties.driver=org.gjt.mm.mysql.Driver
    db.pool.default.jdbcDriver=net.bull.javamelody.JdbcDriver
    db.pool.default.jdbcUrl=jdbc:mysql://localhost:3306/opencms
    db.pool.default.user=opencms
    db.pool.default.password=secret