### PR TITLE
Fixed setup.sh so that running the cms shell outside of WEB-INF is possible

### DIFF
--- a/webapp/WEB-INF/setup.sh
+++ b/webapp/WEB-INF/setup.sh
@@ -42,5 +42,5 @@ tail -f ${OPENCMS_BASE}/logs/setup.log
 trap 'kill $(jobs -pr)' SIGINT SIGTERM EXIT
 
 
-java -classpath "${OPENCMS_CLASSPATH}:${TOMCAT_CLASSPATH}:classes" org.opencms.setup.CmsAutoSetup "$@"
+java -classpath "${OPENCMS_CLASSPATH}:${TOMCAT_CLASSPATH}:${OPENCMS_BASE}/classes" org.opencms.setup.CmsAutoSetup "$@"
 


### PR DESCRIPTION
Running the setup shell script was only possible when the working directory was [webapp-basepath]/WEB-INF, because the classpath contained the relative directory "classes".
This was fixed by adding "${OPENCMS_BASE}/" before classes.