### PR TITLE
FIX modified mysql create tables to support innodb

### DIFF
--- a/webapp/setup/database/mysql/create_tables.sql
+++ b/webapp/setup/database/mysql/create_tables.sql
@@ -506,7 +506,7 @@ CREATE TABLE CMS_ALIASES
      site_root    VARCHAR(64) NOT NULL,
      alias_mode   INTEGER NOT NULL,
      structure_id VARCHAR(36) NOT NULL,
-     PRIMARY KEY (path, site_root)
+     PRIMARY KEY (path(255), site_root)
   )
 ENGINE = MYISAM
 CHARACTER SET UTF8;


### PR DESCRIPTION
Patched create_tables.sql as to allow engine change in mysql. As innodb does not support keys larger than 767 bytes, I shortened the path part of CMS_ALIASES Primary Key.
This does not affect application logic and would not affect performance: worst case is when all paths are 256 char long and the first 255 chars are equal => this means mysql needs to do a full table scan. (but who is generating aliases 256 chars long by varying only the last char?)