### PR TITLE
Automatic setup: fail on unsupported provider

### DIFF
--- a/src-setup/org/opencms/setup/CmsSetupBean.java
+++ b/src-setup/org/opencms/setup/CmsSetupBean.java
@@ -2057,6 +2057,14 @@ public class CmsSetupBean implements I_CmsShellCommands {
             || provider.equals(DB2_PROVIDER)) {
             isFormSubmitted = (isFormSubmitted && (database != null));
         }
+        if (!(JPA_PROVIDER.equals(provider)
+            || MAXDB_PROVIDER.equals(provider)
+            || MSSQL_PROVIDER.equals(provider)
+            || MYSQL_PROVIDER.equals(provider)
+            || ORACLE_PROVIDER.equals(provider)
+            || POSTGRESQL_PROVIDER.equals(provider))) {
+            throw new RuntimeException("Database provider '" + provider + "' not supported!");
+        }
 
         if (isInitialized()) {
             String createDb = getReqValue(request, "createDb");

--- a/src-setup/org/opencms/setup/setup.properties.example
+++ b/src-setup/org/opencms/setup/setup.properties.example
@@ -3,7 +3,7 @@ setup.default.webapp=ROOT
 setup.install.components=workplace,bootstrap
 
 db.product=mysql
-db.provider=sql
+db.provider=mysql
 db.create.user=root
 db.create.pwd=
 db.worker.user=root


### PR DESCRIPTION
Test if the configured provider is supported. A misconfigured provider results in a cryptic and misleading error message `DROP DATABASE ${database} [...] You have an error in your SQL syntax [...]`.