### PR TITLE
Remove warning during import of workplace module

### DIFF
--- a/modules/org.opencms.workplace.help.de/resources/system/workplace/locales/de/help/explorer/newresource/pointer.html
+++ b/modules/org.opencms.workplace.help.de/resources/system/workplace/locales/de/help/explorer/newresource/pointer.html
@@ -8,10 +8,7 @@
           <target><![CDATA[/system/workplace/locales/de/help/explorer/popupMenu/properties.html]]></target>
           <uuid>f756a6cf-11b7-11db-91cd-fdbae480bac9</uuid>
         </link>
-        <link name="link0" internal="false" type="A">
-          <target><![CDATA[http://]]></target>
-        </link>
-        <link name="link1" internal="true" type="A">
+        <link name="link0" internal="true" type="A">
           <target><![CDATA[/system/workplace/locales/de/help/explorer/popupMenu/properties.html]]></target>
           <uuid>f756a6cf-11b7-11db-91cd-fdbae480bac9</uuid>
         </link>
@@ -31,11 +28,11 @@ Dialogfenstern werden alle relevanten Parameter abgefragt.</p>
   Fehlermeldung zur Folge. Achten Sie auf eine durchgängige Kleinschreibung.</li><li> <b>Link
 URL&nbsp;<br>
 </b> Geben Sie hier die URL der zu verlinkenden Seite an. Vergessen
-Sie nicht das <a href="%(link0)"><u>http://</u></a> voranzustellen.</li><li> Sofern die
+Sie nicht das <a><u>http://</u></a> voranzustellen.</li><li> Sofern die
 Eigenschaft „<i>Bearbeite Eigenschaften der neuen Datei</i>“ aktiviert 
   wurde, wird der Dialogverlauf entsprechend um zwei weiteren Eingabefenstern 
   erweitert In diesen können die <A 
-  href="%(link1)" 
+  href="%(link0)" 
   target=_self>Eigenschaften</A> 
   der zu erstellenden Datei vergeben werden</li><li>
 <b>Dialogfenster: Eigenschaften&nbsp;&nbsp;<br>

--- a/modules/org.opencms.workplace.help.de/resources/system/workplace/locales/de/help/explorer/popupMenu/secure.html
+++ b/modules/org.opencms.workplace.help.de/resources/system/workplace/locales/de/help/explorer/popupMenu/secure.html
@@ -3,11 +3,6 @@
 <pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.opencms.org/dtd/6.0/xmlpage.xsd">
   <page language="de">
     <element name="body">
-      <links>
-        <link name="link0" internal="false" type="A">
-          <target><![CDATA[https://]]></target>
-        </link>
-      </links>
       <content><![CDATA[<p>      
  Aktiviert eine verschlüsselte Übertragung für die ausgewählte
 Ressource. Inhalte sollten unbedingt verschlüsselt übertragen werden, wenn sie
@@ -21,7 +16,7 @@ entsprechenden Einstellungen vorgenommen werden können.&nbsp;</p>
 </b> Wird hier der Wert „<i>Ja</i>“ gesetzt, wird die Datei bei
 einem Aufruf durch einen Leser verschlüsselt übermittelt, sofern
 Sie über die Seiten- oder Kopfnavigation aufgerufen wird. Erkennbar
-ist eine verschlüsselte Seite an dem <A href="%(link0)"><u>https://</u></A> in der Adresszeile des Browsers. Auch in 
+ist eine verschlüsselte Seite an dem <A><u>https://</u></A> in der Adresszeile des Browsers. Auch in 
   der Statuszeile des Browsers wird auf die SSL-Verschlüsselung hingewiesen. Der 
   Dialog ist nur dann aktiviert, wenn für die Site, in der sich die Seite 
   befindet, auch ein sicherer Server konfiguriert ist.</li><li><b>Intern&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br>

--- a/modules/org.opencms.workplace.help.de/resources/system/workplace/locales/de/help/explorer/popupMenu/secure.html
+++ b/modules/org.opencms.workplace.help.de/resources/system/workplace/locales/de/help/explorer/popupMenu/secure.html
@@ -3,6 +3,7 @@
 <pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.opencms.org/dtd/6.0/xmlpage.xsd">
   <page language="de">
     <element name="body">
+      <links/>
       <content><![CDATA[<p>      
  Aktiviert eine verschlüsselte Übertragung für die ausgewählte
 Ressource. Inhalte sollten unbedingt verschlüsselt übertragen werden, wenn sie


### PR DESCRIPTION
During parsing of resources, two invalid URIs triggered an Exception. This was correctly handled, but the warning message was annoying.