### PR TITLE
Fix key shortcut in CodeMirror widget

### DIFF
--- a/modules/org.opencms.editors.tinymce/static/editors/tinymce/jscripts/tinymce/plugins/codemirror/source.html
+++ b/modules/org.opencms.editors.tinymce/static/editors/tinymce/jscripts/tinymce/plugins/codemirror/source.html
@@ -113,7 +113,12 @@ function start()
 		div = parent.document.createElement('div'),
 		td1 = '<td style="font-size:11px;background:#777;color:#fff;padding:0 4px">',
 		td2 = '<td style="font-size:11px;padding-right:5px">';
-	div.innerHTML = '<table cellspacing="0" cellpadding="0" style="border-spacing:4px"><tr>' + td1 + (isMac ? '&#8984;-F' : 'Ctrl-F</td>') + td2 + tinymce.translate('Start search') + '</td>' + td1 + (isMac ? '&#8984;-G' : 'Ctrl-G') + '</td>' + td2 + tinymce.translate('Find next') + '</td>' + td1 + (isMac ? '&#8984;-Alt-F' : 'Shift-Ctrl-F') + '</td>' + td2 + tinymce.translate('Find previous') + '</td></tr>' + '<tr>' + td1 + (isMac ? '&#8984;-Alt-F' : 'Shift-Ctrl-F') + '</td>' + td2 + tinymce.translate('Replace') + '</td>' + td1 + (isMac ? 'Shift-&#8984;-Alt-F' : 'Shift-Ctrl-R') +'</td>' + td2 + tinymce.translate('Replace all') + '</td></tr></table>';
+	div.innerHTML = '<table cellspacing="0" cellpadding="0" style="border-spacing:4px"><tr>'
+		+ td1 + (isMac ? '&#8984;-F' : 'Ctrl-F</td>') + td2 + tinymce.translate('Start search') + '</td>'
+		+ td1 + (isMac ? '&#8984;-G' : 'Ctrl-G') + '</td>' + td2 + tinymce.translate('Find next') + '</td>'
+		+ td1 + (isMac ? 'Shift-&#8984;-G' : 'Shift-Ctrl-G') + '</td>' + td2 + tinymce.translate('Find previous') + '</td></tr>' + '<tr>'
+		+ td1 + (isMac ? '&#8984;-Alt-F' : 'Shift-Ctrl-F') + '</td>' + td2 + tinymce.translate('Replace') + '</td>'
+		+ td1 + (isMac ? 'Shift-&#8984;-Alt-F' : 'Shift-Ctrl-R') +'</td>' + td2 + tinymce.translate('Replace all') + '</td></tr></table>';
 	div.style.position = 'absolute';
 	div.style.left = div.style.bottom = '5px';
 	head.appendChild(div);


### PR DESCRIPTION
Fix shortcut "Find previous"

Compare:
![codemirror_wrong](https://cloud.githubusercontent.com/assets/790448/15533479/1ff17eec-2265-11e6-959f-3a805f76d898.png)
vs
![codemirror_fixed](https://cloud.githubusercontent.com/assets/790448/15533485/246d43fc-2265-11e6-9712-3a34725dd07f.png)
