### PR TITLE
Fix spellcheck in TinyMCE is always done with 'en' dictionary

### DIFF
--- a/src/org/opencms/search/solr/spellchecking/CmsSolrSpellchecker.java
+++ b/src/org/opencms/search/solr/spellchecking/CmsSolrSpellchecker.java
@@ -375,13 +375,13 @@ public final class CmsSolrSpellchecker {
     private CmsSpellcheckingRequest parseJsonRequest(JSONObject jsonRequest) {
 
         final String id = jsonRequest.optString(JSON_ID);
-        final String lang = jsonRequest.optString(JSON_LANG, LANG_DEFAULT);
         final JSONObject params = jsonRequest.optJSONObject(JSON_PARAMS);
 
         if (null == params) {
             LOG.debug("Invalid JSON request: No field \"params\" defined. ");
             return null;
         }
+        final String lang = params.optString(JSON_LANG, LANG_DEFAULT);
         final JSONArray words = params.optJSONArray(JSON_WORDS);
 
         if (null == words) {

--- a/src/org/opencms/widgets/CmsHtmlWidget.java
+++ b/src/org/opencms/widgets/CmsHtmlWidget.java
@@ -411,9 +411,7 @@ public class CmsHtmlWidget extends A_CmsHtmlWidget implements I_CmsADEWidget {
                         cms,
                         OpenCmsSpellcheckHandler.getSpellcheckHandlerPath()));
 
-                result.put(
-                    "spellcheck_language",
-                    "+" + contentLocale.getDisplayLanguage(workplaceLocale) + "=" + contentLocale.getLanguage());
+                result.put("spellcheck_language", contentLocale.getLanguage());
             }
         } catch (JSONException e) {
             LOG.error(e.getLocalizedMessage(), e);


### PR DESCRIPTION
The spellcheck in TinyMCE doesn't work with other languages than English. There are two odd things:

The class CmsHtmlWidget generates a configuration value like: `"spellcheck_language": "+German=de"`.

When spellcheck should be performed, the TinyMCE sends a POST request with JSON body: 

```
{
    "id": "c0",
    "method": "spellcheck",
    "params": {
        "lang": "de",
        "words": ["Auch", "gibt", "es"]
    }
}
```

But the CmsSolrSpellchecker tries to get the lang attribute form the same level as id, which seems to be wrong.

This pull request changes the JSON config to: `"spellcheck_language": "[content locale]"` and retrieve _lang_ attribute from _params_
