### PR TITLE
New tag cms:scaleImage

### DIFF
--- a/src/org/opencms/jsp/CmsJspImageScalerTagSupport.java
+++ b/src/org/opencms/jsp/CmsJspImageScalerTagSupport.java
@@ -1,0 +1,303 @@
+
+package org.opencms.jsp;
+
+import org.opencms.loader.CmsImageScaler;
+import org.opencms.util.CmsStringUtil;
+
+import javax.servlet.jsp.tagext.BodyTagSupport;
+
+/**
+ * Abstract parent for all JSP tags dealing with image scaling, defines some common image scaler
+ * properties and corresponding getters/setters that may be used by extending classes.
+ */
+public abstract class CmsJspImageScalerTagSupport extends BodyTagSupport {
+
+    /** Serial version UID required for safe serialization. */
+    private static final long serialVersionUID = 1303030767942208144L;
+
+    /** Required image scaler attributes constant. */
+    protected static final String SCALE_ATTR_HEIGHT = "height";
+
+    /** Required image scaler attributes constant. */
+    protected static final String SCALE_ATTR_MAXHEIGHT = "maxHeight";
+
+    /** Required image scaler attributes constant. */
+    protected static final String SCALE_ATTR_MAXWIDTH = "maxWidth";
+
+    /** Required image scaler attributes constant. */
+    protected static final String SCALE_ATTR_POSITION = "scaleposition";
+
+    /** Required image scaler attributes constant. */
+    protected static final String SCALE_ATTR_QUALITY = "scalequality";
+
+    /** Required image scaler attributes constant. */
+    protected static final String SCALE_ATTR_RENDERMODE = "scalerendermode";
+
+    /** Required image scaler attributes constant. */
+    protected static final String SCALE_ATTR_TYPE = "scaletype";
+
+    /** Required image scaler attributes constant. */
+    protected static final String SCALE_ATTR_WIDTH = "width";
+
+    /** The given image scaler parameters. */
+    protected transient CmsImageScaler m_scaler;
+
+    /** The image source. */
+    protected String m_src;
+
+    /**
+     * Initializes a CmsImageScaler to be used by derived classes. The CmsImageScaler is recreated
+     * every time {@link #release()} is called.
+     */
+    public CmsJspImageScalerTagSupport() {
+        // initialize the image scaler parameter container
+        m_scaler = new CmsImageScaler();
+    }
+
+    /**
+     * Returns the scaling height for the image.<p>
+     *
+     * @return the scaling height for the image
+     */
+    public String getHeight() {
+
+        return String.valueOf(m_scaler.getHeight());
+    }
+
+    /**
+     * Returns the maximum scaling height for the image, only needed if scale type is 5.<p>
+     *
+     * @return the maximum scaling height for the image
+     */
+    public String getMaxHeight() {
+
+        return String.valueOf(m_scaler.getMaxHeight());
+    }
+
+    /**
+     * Returns the maximum scaling width for the image, only needed if scale type is 5.<p>
+     *
+     * @return the maximum scaling width for the image
+     */
+    public String getMaxWidth() {
+
+        return String.valueOf(m_scaler.getMaxWidth());
+    }
+
+    /**
+     * Returns the background color used by the image scaler.<p>
+     *
+     * @return the background color used by the image scaler
+     */
+    public String getScaleColor() {
+
+        return m_scaler.getColorString();
+    }
+
+    /**
+     * Returns the filter list used by the image scaler.<p>
+     *
+     * @return the filter list used by the image scaler
+     */
+    public String getScaleFilter() {
+
+        return m_scaler.getFiltersString();
+    }
+
+    /**
+     * Returns the position used by the image scaler.<p>
+     *
+     * @return the position used by the image scaler
+     */
+    public String getScalePosition() {
+
+        return String.valueOf(m_scaler.getPosition());
+    }
+
+    /**
+     * Returns the quality used by the image scaler.<p>
+     *
+     * @return the quality used by the image scaler
+     */
+    public String getScaleQuality() {
+
+        return String.valueOf(m_scaler.getQuality());
+    }
+
+    /**
+     * Returns the render mode used by the image scaler.<p>
+     *
+     * @return the render mode used by the image scaler
+     */
+    public String getScaleRendermode() {
+
+        return String.valueOf(m_scaler.getRenderMode());
+    }
+
+    /**
+     * Returns the scaling type for the image.<p>
+     *
+     * @return the scaling type for the image
+     */
+    public String getScaleType() {
+
+        return String.valueOf(m_scaler.getType());
+    }
+
+    /**
+     * Returns the source of the image to scale,
+     * which will have the OpenCms webapp / servlet prefix added.<p>
+     *
+     * @return the source of the image to scale
+     */
+    public String getSrc() {
+
+        return m_src;
+    }
+
+    /**
+     * Returns the scaling width for the image.<p>
+     *
+     * @return the scaling width for the image
+     */
+    public String getWidth() {
+
+        return String.valueOf(m_scaler.getWidth());
+    }
+
+    /**
+     * Does some cleanup and creates a new ImageScaler before the tag is released to the tag pool.
+     *
+     * @see javax.servlet.jsp.tagext.Tag#release()
+     */
+    @Override
+    public void release() {
+
+        m_scaler = new CmsImageScaler();
+        m_src = null;
+        super.release();
+    }
+
+    /**
+     * Sets the scaling height for the image.<p>
+     *
+     * If no valid integer is given, then "0" is used as value.<p>
+     *
+     * @param value the scaling height for the image to set
+     */
+    public void setHeight(String value) {
+
+        m_scaler.setHeight(CmsStringUtil.getIntValueRounded(value, 0, SCALE_ATTR_HEIGHT));
+    }
+
+    /**
+     * Sets the maximum scaling height for the image, only needed if scale type is 5.<p>
+     *
+     * If no valid integer is given, then the value of {@link #getHeight()} is used as value.<p>
+     *
+     * @param value the maximum scaling height for the image to set
+     */
+    public void setMaxHeight(String value) {
+
+        m_scaler.setMaxHeight(CmsStringUtil.getIntValueRounded(value, -1, SCALE_ATTR_MAXHEIGHT));
+    }
+
+    /**
+     * Sets the maximum scaling width for the image, only needed if scale type is 5.<p>
+     *
+     * If no valid integer is given, then the value of {@link #getWidth()} is used as value.<p>
+     *
+     * @param value the maximum scaling width for the image to set
+     */
+    public void setMaxWidth(String value) {
+
+        m_scaler.setMaxWidth(CmsStringUtil.getIntValueRounded(value, -1, SCALE_ATTR_MAXWIDTH));
+    }
+
+    /**
+     * Sets the background color used by the image scaler.<p>
+     *
+     * @param value the background color to set
+     */
+    public void setScaleColor(String value) {
+
+        m_scaler.setColor(value);
+    }
+
+    /**
+     * Sets the filter(s) used by the image scaler.<p>
+     *
+     * @param value the filter(s) to set
+     */
+    public void setScaleFilter(String value) {
+
+        m_scaler.setFilters(value);
+    }
+
+    /**
+     * Sets the position used by the image scaler.<p>
+     *
+     * @param value the position to set
+     */
+    public void setScalePosition(String value) {
+
+        m_scaler.setPosition(CmsStringUtil.getIntValue(value, 0, SCALE_ATTR_POSITION));
+    }
+
+    /**
+     * Sets the quality used by the image scaler.<p>
+     *
+     * @param value the quality to set
+     */
+    public void setScaleQuality(String value) {
+
+        m_scaler.setQuality(CmsStringUtil.getIntValue(value, 0, SCALE_ATTR_QUALITY));
+    }
+
+    /**
+     * Sets the render mode used by the image scaler.<p>
+     *
+     * @param value the render mode to set
+     */
+    public void setScaleRendermode(String value) {
+
+        m_scaler.setRenderMode(CmsStringUtil.getIntValue(value, 0, SCALE_ATTR_RENDERMODE));
+    }
+
+    /**
+     * Sets the scaling type for the image.<p>
+     *
+     * If no valid integer is given, then "0" is used as value.<p>
+     *
+     * @param value the scaling type for the image to set
+     */
+    public void setScaleType(String value) {
+
+        m_scaler.setType(CmsStringUtil.getIntValue(value, 0, SCALE_ATTR_TYPE));
+    }
+
+    /**
+     * Sets the source of the image.<p>
+     *
+     * The source must be an absolute path in the current users OpenCms site, without any
+     * webapp or servlet prefix.<p>
+     *
+     * @param value the image source to set
+     */
+    public void setSrc(String value) {
+
+        m_src = value;
+    }
+
+    /**
+     * Sets the scaling width for the image.<p>
+     *
+     * If no valid integer is given, then "0" is used as value.<p>
+     *
+     * @param value the scaling width for the image to set
+     */
+    public void setWidth(String value) {
+
+        m_scaler.setWidth(CmsStringUtil.getIntValueRounded(value, 0, SCALE_ATTR_WIDTH));
+    }
+}

--- a/src/org/opencms/jsp/CmsJspTagImage.java
+++ b/src/org/opencms/jsp/CmsJspTagImage.java
@@ -47,7 +47,6 @@ import java.util.Map;
 
 import javax.servlet.ServletRequest;
 import javax.servlet.jsp.JspException;
-import javax.servlet.jsp.tagext.BodyTagSupport;
 
 import org.apache.commons.logging.Log;
 
@@ -56,7 +55,7 @@ import org.apache.commons.logging.Log;
  *
  * @since 6.2.0
  */
-public class CmsJspTagImage extends BodyTagSupport implements I_CmsJspTagParamParent {
+public class CmsJspTagImage extends CmsJspImageScalerTagSupport implements I_CmsJspTagParamParent {
 
     /** Optional HTML attribute constant. */
     private static final String ATTR_ALIGN = "align";
@@ -104,37 +103,13 @@ public class CmsJspTagImage extends BodyTagSupport implements I_CmsJspTagParamPa
     private static final String SCALE_ATTR_FILTER = "scalefilter";
 
     /** Required image scaler attributes constant. */
-    private static final String SCALE_ATTR_HEIGHT = "height";
-
-    /** Required image scaler attributes constant. */
-    private static final String SCALE_ATTR_MAXHEIGHT = "maxHeight";
-
-    /** Required image scaler attributes constant. */
-    private static final String SCALE_ATTR_MAXWIDTH = "maxWidth";
-
-    /** Required image scaler attributes constant. */
     private static final String SCALE_ATTR_NODIM = "nodim";
 
     /** Required image scaler attributes constant. */
     private static final String SCALE_ATTR_PARTIALTAG = "partialtag";
 
     /** Required image scaler attributes constant. */
-    private static final String SCALE_ATTR_POSITION = "scaleposition";
-
-    /** Required image scaler attributes constant. */
-    private static final String SCALE_ATTR_QUALITY = "scalequality";
-
-    /** Required image scaler attributes constant. */
-    private static final String SCALE_ATTR_RENDERMODE = "scalerendermode";
-
-    /** Required image scaler attributes constant. */
     private static final String SCALE_ATTR_SRC = "src";
-
-    /** Required image scaler attributes constant. */
-    private static final String SCALE_ATTR_TYPE = "scaletype";
-
-    /** Required image scaler attributes constant. */
-    private static final String SCALE_ATTR_WIDTH = "width";
 
     /** Lists for fast lookup. */
     private static final String[] SCALER_ATTRS = {
@@ -167,19 +142,11 @@ public class CmsJspTagImage extends BodyTagSupport implements I_CmsJspTagParamPa
     /** Controls if the created HTML image tag is a full or partial tag. */
     private boolean m_partialTag;
 
-    /** The given image scaler parameters. */
-    private transient CmsImageScaler m_scaler;
-
-    /** The image source. */
-    private String m_src;
-
     /**
      * Creates a new image scaling tag instance.<p>
      */
     public CmsJspTagImage() {
-
-        // initialize the image scaler parameter container
-        m_scaler = new CmsImageScaler();
+        super();
     }
 
     /**
@@ -235,7 +202,8 @@ public class CmsJspTagImage extends BodyTagSupport implements I_CmsJspTagParamPa
         Map<String, String> attributes,
         boolean partialTag,
         boolean noDim,
-        ServletRequest req) throws CmsException {
+        ServletRequest req)
+    throws CmsException {
 
         CmsFlexController controller = CmsFlexController.getController(req);
         CmsObject cms = controller.getCmsObject();
@@ -322,7 +290,8 @@ public class CmsJspTagImage extends BodyTagSupport implements I_CmsJspTagParamPa
         CmsImageScaler scaler,
         Map<String, String> attributes,
         boolean partialTag,
-        ServletRequest req) throws CmsException {
+        ServletRequest req)
+    throws CmsException {
 
         return imageTagAction(src, scaler, attributes, partialTag, false, req);
     }
@@ -469,16 +438,6 @@ public class CmsJspTagImage extends BodyTagSupport implements I_CmsJspTagParamPa
     }
 
     /**
-     * Returns the scaling height for the image.<p>
-     *
-     * @return the scaling height for the image
-     */
-    public String getHeight() {
-
-        return String.valueOf(m_scaler.getHeight());
-    }
-
-    /**
      * Returns the value of the HTML "hspace" attribute.<p>
      *
      * @return the value of the HTML "hspace" attribute
@@ -510,26 +469,6 @@ public class CmsJspTagImage extends BodyTagSupport implements I_CmsJspTagParamPa
     }
 
     /**
-     * Returns the maximum scaling height for the image, only needed if scale type is 5.<p>
-     *
-     * @return the maximum scaling height for the image
-     */
-    public String getMaxHeight() {
-
-        return String.valueOf(m_scaler.getMaxHeight());
-    }
-
-    /**
-     * Returns the maximum scaling width for the image, only needed if scale type is 5.<p>
-     *
-     * @return the maximum scaling width for the image
-     */
-    public String getMaxWidth() {
-
-        return String.valueOf(m_scaler.getMaxWidth());
-    }
-
-    /**
      * Returns the value of the HTML "name" attribute.<p>
      *
      * @return the value of the HTML "name" attribute
@@ -548,77 +487,6 @@ public class CmsJspTagImage extends BodyTagSupport implements I_CmsJspTagParamPa
     public String getNoDim() {
 
         return String.valueOf(m_noDim);
-    }
-
-    /**
-     * Returns the background color used by the image scaler.<p>
-     *
-     * @return the background color used by the image scaler
-     */
-    public String getScaleColor() {
-
-        return m_scaler.getColorString();
-    }
-
-    /**
-     * Returns the filter list used by the image scaler.<p>
-     *
-     * @return the filter list used by the image scaler
-     */
-    public String getScaleFilter() {
-
-        return m_scaler.getFiltersString();
-    }
-
-    /**
-     * Returns the position used by the image scaler.<p>
-     *
-     * @return the position used by the image scaler
-     */
-    public String getScalePosition() {
-
-        return String.valueOf(m_scaler.getPosition());
-    }
-
-    /**
-     * Returns the quality used by the image scaler.<p>
-     *
-     * @return the quality used by the image scaler
-     */
-    public String getScaleQuality() {
-
-        return String.valueOf(m_scaler.getQuality());
-    }
-
-    /**
-     * Returns the render mode used by the image scaler.<p>
-     *
-     * @return the render mode used by the image scaler
-     */
-    public String getScaleRendermode() {
-
-        return String.valueOf(m_scaler.getRenderMode());
-    }
-
-    /**
-     * Returns the scaling type for the image.<p>
-     *
-     * @return the scaling type for the image
-     */
-    public String getScaleType() {
-
-        return String.valueOf(m_scaler.getType());
-    }
-
-    /**
-     * Returns the source of the image to scale,
-     * which will have the OpenCms webapp / servlet prefix added.<p>
-     *
-     * @return the source of the image to scale
-     */
-    public String getSrc() {
-
-        return m_src;
     }
 
     /**
@@ -662,16 +530,6 @@ public class CmsJspTagImage extends BodyTagSupport implements I_CmsJspTagParamPa
     }
 
     /**
-     * Returns the scaling width for the image.<p>
-     *
-     * @return the scaling width for the image
-     */
-    public String getWidth() {
-
-        return String.valueOf(m_scaler.getWidth());
-    }
-
-    /**
      * Returns <code>"true"</code> if the HTML tag should only be created as partial tag.<p>
      *
      * @return <code>"true"</code> if the HTML tag should only be created as partial tag
@@ -688,10 +546,8 @@ public class CmsJspTagImage extends BodyTagSupport implements I_CmsJspTagParamPa
     public void release() {
 
         m_attributes = null;
-        m_scaler = new CmsImageScaler();
         m_partialTag = false;
         m_noDim = false;
-        m_src = null;
         super.release();
     }
 
@@ -739,18 +595,6 @@ public class CmsJspTagImage extends BodyTagSupport implements I_CmsJspTagParamPa
     }
 
     /**
-     * Sets the scaling height for the image.<p>
-     *
-     * If no valid integer is given, then "0" is used as value.<p>
-     *
-     * @param value the scaling height for the image to set
-     */
-    public void setHeight(String value) {
-
-        m_scaler.setHeight(CmsStringUtil.getIntValueRounded(value, 0, SCALE_ATTR_HEIGHT));
-    }
-
-    /**
      * Sets the value of the HTML "hspace" attribute.<p>
      *
      * @param value the value of the HTML "hspace" attribute to set
@@ -785,30 +629,6 @@ public class CmsJspTagImage extends BodyTagSupport implements I_CmsJspTagParamPa
     }
 
     /**
-     * Sets the maximum scaling height for the image, only needed if scale type is 5.<p>
-     *
-     * If no valid integer is given, then the value of {@link #getHeight()} is used as value.<p>
-     *
-     * @param value the maximum scaling height for the image to set
-     */
-    public void setMaxHeight(String value) {
-
-        m_scaler.setMaxHeight(CmsStringUtil.getIntValueRounded(value, -1, SCALE_ATTR_MAXHEIGHT));
-    }
-
-    /**
-     * Sets the maximum scaling width for the image, only needed if scale type is 5.<p>
-     *
-     * If no valid integer is given, then the value of {@link #getWidth()} is used as value.<p>
-     *
-     * @param value the maximum scaling width for the image to set
-     */
-    public void setMaxWidth(String value) {
-
-        m_scaler.setMaxWidth(CmsStringUtil.getIntValueRounded(value, -1, SCALE_ATTR_MAXWIDTH));
-    }
-
-    /**
      * Sets the value of the HTML "name" attribute.<p>
      *
      * @param value the value of the HTML "name" attribute to set
@@ -837,81 +657,6 @@ public class CmsJspTagImage extends BodyTagSupport implements I_CmsJspTagParamPa
     public void setPartialTag(String partialTag) {
 
         m_partialTag = Boolean.valueOf(partialTag).booleanValue();
-    }
-
-    /**
-     * Sets the background color used by the image scaler.<p>
-     *
-     * @param value the background color to set
-     */
-    public void setScaleColor(String value) {
-
-        m_scaler.setColor(value);
-    }
-
-    /**
-     * Sets the filter(s) used by the image scaler.<p>
-     *
-     * @param value the filter(s) to set
-     */
-    public void setScaleFilter(String value) {
-
-        m_scaler.setFilters(value);
-    }
-
-    /**
-     * Sets the position used by the image scaler.<p>
-     *
-     * @param value the position to set
-     */
-    public void setScalePosition(String value) {
-
-        m_scaler.setPosition(CmsStringUtil.getIntValue(value, 0, SCALE_ATTR_POSITION));
-    }
-
-    /**
-     * Sets the quality used by the image scaler.<p>
-     *
-     * @param value the quality to set
-     */
-    public void setScaleQuality(String value) {
-
-        m_scaler.setQuality(CmsStringUtil.getIntValue(value, 0, SCALE_ATTR_QUALITY));
-    }
-
-    /**
-     * Sets the render mode used by the image scaler.<p>
-     *
-     * @param value the render mode to set
-     */
-    public void setScaleRendermode(String value) {
-
-        m_scaler.setRenderMode(CmsStringUtil.getIntValue(value, 0, SCALE_ATTR_RENDERMODE));
-    }
-
-    /**
-     * Sets the scaling type for the image.<p>
-     *
-     * If no valid integer is given, then "0" is used as value.<p>
-     *
-     * @param value the scaling type for the image to set
-     */
-    public void setScaleType(String value) {
-
-        m_scaler.setType(CmsStringUtil.getIntValue(value, 0, SCALE_ATTR_TYPE));
-    }
-
-    /**
-     * Sets the source of the image.<p>
-     *
-     * The source must be an absolute path in the current users OpenCms site, without any
-     * webapp or servlet prefix.<p>
-     *
-     * @param value the image source to set
-     */
-    public void setSrc(String value) {
-
-        m_src = value;
     }
 
     /**
@@ -953,18 +698,6 @@ public class CmsJspTagImage extends BodyTagSupport implements I_CmsJspTagParamPa
 
         setAttribute(ATTR_VSPACE, value);
 
-    }
-
-    /**
-     * Sets the scaling width for the image.<p>
-     *
-     * If no valid integer is given, then "0" is used as value.<p>
-     *
-     * @param value the scaling width for the image to set
-     */
-    public void setWidth(String value) {
-
-        m_scaler.setWidth(CmsStringUtil.getIntValueRounded(value, 0, SCALE_ATTR_WIDTH));
     }
 
     /**

--- a/src/org/opencms/jsp/CmsJspTagScaleImage.java
+++ b/src/org/opencms/jsp/CmsJspTagScaleImage.java
@@ -1,0 +1,330 @@
+
+package org.opencms.jsp;
+
+import org.opencms.file.CmsObject;
+import org.opencms.file.CmsResource;
+import org.opencms.flex.CmsFlexController;
+import org.opencms.jsp.util.CmsJspImageBean;
+import org.opencms.jsp.util.CmsJspScaledImageBean;
+import org.opencms.loader.CmsImageScaler;
+import org.opencms.main.CmsException;
+import org.opencms.main.CmsLog;
+import org.opencms.main.OpenCms;
+import org.opencms.staticexport.CmsLinkManager;
+import org.opencms.util.CmsRequestUtil;
+import org.opencms.util.CmsUriSplitter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.jsp.JspException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.commons.logging.Log;
+
+/**
+ * This tag allows using the OpenCms native image scaling mechanism within JSP.
+ * It generates a ScaledImage bean that can be used to include the selected image, adding the
+ * required image scaling parameters.<br/><br/>
+ * The following image formats are supported: BMP, GIF, JPEG, PNG, PNM, TIFF.
+ * <em>
+ * Note: Picture scaling is by default only enabled for target size with width and height
+ * &lt;=1500. The size can be changed in the image scaler configuration in the file
+ * <code>opencms-vfs.xml</code> in the body of the tag <code>&lt;loader&gt;</code>. Also other
+ * options for the image scaler are set there.
+ * <br/><br/>
+ * This tag is an alternative to the OpenCms standard tag cms:img, providing more flexibility by
+ * not generating any output but providing a bean that may be used to generate any output needed.
+ * This way you can use scaled images for
+ * <ul>
+ *   <li>The standard img-Tag</li>
+ *   <li>
+ *     The more modern picture-Tag with multiple sources (hi-DPI variants for retina displays)
+ *     for responsive design
+ *   </li>
+ *   <li>Background-Image integration</li>
+ * </ul>
+ * </em>
+ */
+public class CmsJspTagScaleImage extends CmsJspImageScalerTagSupport {
+
+    /** The log object for this class. */
+    private static final Log LOG = CmsLog.getLog(CmsJspTagScaleImage.class);
+
+    /** Serial version UID required for safe serialization. */
+    private static final long serialVersionUID = -6639978110802734737L;
+
+    /** List of hi-DPI variant sizes to produce, e.g. 1.3x, 1.5x, 2x, 3x */
+    private List<String> m_hiDpiVariantList;
+
+    /** Name of the request attribute used to store the ScaledImageBean bean */
+    private String m_var;
+
+    /**
+     * Creates a new image scaling tag instance.<p>
+     */
+    public CmsJspTagScaleImage() {
+        super();
+    }
+
+    /**
+     * Does some cleanup before returning EVAL_PAGE
+     *
+     * @see javax.servlet.jsp.tagext.Tag#doEndTag()
+     */
+    @SuppressWarnings("unused")
+    @Override
+    public int doEndTag() throws JspException {
+
+        release();
+        return EVAL_PAGE;
+    }
+
+    /**
+     * Handles the Start tag, checks some parameters, uses the CmsImageScaler to create a scaled
+     * version of the image (and hi-DPI variants if necessary), stores all information in a
+     * ScaledImageBean and stores it as a request attribute (the name for this attribute is given
+     * with the tag attribute "var").
+     *
+     * @return EVAL_BODY_INCLUDE or SKIP_BODY in case of an unexpected Exception (please consult
+     * the OpenCms log file if that happens)
+     *
+     * @throws JspException in case of invalid attributes (if neither width nor height is set)
+     */
+    @Override
+    public int doStartTag() throws JspException {
+
+        if ((m_scaler.getWidth() <= 0) && (m_scaler.getHeight() <= 0)) {
+            throw new JspException("At least one of the attributes width or height has to be set");
+        }
+
+        ServletRequest req = pageContext.getRequest();
+
+        // this will always be true if the page is called through OpenCms
+        if (CmsFlexController.isCmsRequest(req)) {
+
+            try {
+                CmsJspScaledImageBean scaledImage = null;
+                try {
+                    scaledImage = imageTagAction();
+                } catch (CmsException e) {
+                    // any issue accessing the VFS - just return SKIP_BODY
+                    // otherwise template layout will get mixed up with nasty exception messages
+                    if (LOG.isWarnEnabled()) {
+                        LOG.warn(Messages.get().getBundle().key(Messages.ERR_IMAGE_TAG_VFS_ACCESS_1, m_src), e);
+                    }
+                }
+                pageContext.getRequest().setAttribute(m_var, scaledImage);
+            } catch (Exception ex) {
+                if (LOG.isErrorEnabled()) {
+                    LOG.error(Messages.get().getBundle().key(Messages.ERR_PROCESS_TAG_1, "scaleImage"), ex);
+                }
+                return SKIP_BODY;
+            }
+        }
+        return EVAL_BODY_INCLUDE;
+    }
+
+    /**
+     * Does some cleanup before the tag is released to the tag pool
+     *
+     * @see javax.servlet.jsp.tagext.Tag#release()
+     */
+    @Override
+    public void release() {
+
+        m_hiDpiVariantList = null;
+        m_var = null;
+        super.release();
+    }
+
+    /**
+     * Sets the String containing a comma separated list of hi-DPI variants to produce, e.g.
+     * "1.3x,1.5x,2x,3x". Currently in most cases "2x" should suffice to generate an additional
+     * image for retina screens.
+     *
+     * @param value comma separated list of hi-DPI variants to produce, e.g. "1.3x,1.5x,2x,3x"
+     */
+    public void setHiDpiVariants(String value) {
+
+        m_hiDpiVariantList = new ArrayList<>(4);
+        String[] multipliers = StringUtils.split(value, ',');
+        Collections.addAll(m_hiDpiVariantList, multipliers);
+    }
+
+    /**
+     * Sets the name of the variable used for storing the resulting bean.
+     *
+     * @param value name of the resulting CmsJspScaledImage bean
+     */
+    public void setVar(String value) {
+
+        m_var = value;
+    }
+
+    /**
+     * Internal method to handle requested hi-DPI variants, adding ImageBeans for all hi-DPI
+     * variants to <code>scaledImage</code>
+     *
+     * @param cms the current CmsObject
+     * @param imageRes the CMS resource representing the image
+     * @param scaler the CmsImageScaler for the scaled image, will be cloned for each hi-DPI variant
+     * @param scaledImage the ScaledImage bean (scaled images will be added to this)
+     * @param originalScaler the CmsImageScaler containing the information about the original image
+     */
+    private void handleHiDpiVariants(
+        CmsObject cms,
+        CmsResource imageRes,
+        CmsImageScaler scaler,
+        CmsJspScaledImageBean scaledImage,
+        CmsImageScaler originalScaler) {
+
+        int targetWidth = m_scaler.getWidth();
+        int targetHeight = m_scaler.getHeight();
+        int originalWidth = originalScaler.getWidth();
+        int originalHeight = originalScaler.getHeight();
+
+        for (String multiplierString : m_hiDpiVariantList) {
+
+            if (!multiplierString.matches("^[0-9]+(.[0-9]+)?x$")) {
+                if (LOG.isWarnEnabled()) {
+                    LOG.warn(
+                        String.format("Illegal multiplier format: %s not usable for image scaling", multiplierString));
+                }
+                continue;
+            }
+            float multiplier = NumberUtils.createFloat(
+                multiplierString.substring(0, multiplierString.length() - 1)).floatValue();
+            int width = Math.round(targetWidth * multiplier);
+            int height = Math.round(targetHeight * multiplier);
+
+            if ((originalWidth >= width) && (originalHeight >= height)) {
+                CmsImageScaler hiDpiScaler = (CmsImageScaler)scaler.clone();
+                hiDpiScaler.setWidth(width);
+                hiDpiScaler.setHeight(height);
+
+                String imageSrc = cms.getSitePath(imageRes);
+                if (hiDpiScaler.isValid()) {
+                    // now append the scaler parameters
+                    imageSrc += hiDpiScaler.toRequestParam();
+                }
+                CmsJspImageBean image = new CmsJspImageBean();
+                image.setSrcUrl(OpenCms.getLinkManager().substituteLink(cms, imageSrc));
+                image.setWidth(width);
+                image.setHeight(height);
+                image.setScaler(hiDpiScaler);
+                scaledImage.addHiDpiImage(multiplierString, image);
+            }
+        }
+    }
+
+    /**
+     * Internal action method to create the scaled image bean.
+     *
+     * @return the created ScaledImageBean bean
+     *
+     * @throws CmsException in case something goes wrong
+     */
+    private CmsJspScaledImageBean imageTagAction() throws CmsException {
+
+        ServletRequest request = pageContext.getRequest();
+        CmsFlexController controller = CmsFlexController.getController(request);
+        CmsObject cms = controller.getCmsObject();
+
+        // resolve possible relative URI
+        String src = CmsLinkManager.getAbsoluteUri(m_src, controller.getCurrentRequest().getElementUri());
+        CmsUriSplitter splitSrc = new CmsUriSplitter(src);
+
+        String scaleParam = null;
+        if (splitSrc.getQuery() != null) {
+            // check if the original URI already has parameters, this is true if original has been cropped
+            String[] scaleStr = CmsRequestUtil.createParameterMap(splitSrc.getQuery()).get(CmsImageScaler.PARAM_SCALE);
+            if (scaleStr != null) {
+                scaleParam = scaleStr[0];
+            }
+        }
+
+        CmsResource imageRes = cms.readResource(splitSrc.getPrefix());
+        CmsImageScaler originalScaler = new CmsImageScaler(cms, imageRes);
+        initScaler(originalScaler, scaleParam);
+
+        String imageSrc = cms.getSitePath(imageRes);
+        if (m_scaler.isValid()) {
+            // now append the scaler parameters
+            imageSrc += m_scaler.toRequestParam();
+        }
+
+        CmsJspScaledImageBean scaledImage = new CmsJspScaledImageBean();
+        scaledImage.setSrcUrl(OpenCms.getLinkManager().substituteLink(cms, imageSrc));
+        scaledImage.setWidth(m_scaler.getWidth());
+        scaledImage.setHeight(m_scaler.getHeight());
+        scaledImage.setScaler(m_scaler);
+
+        // now handle hi-DPI variants
+        if ((m_hiDpiVariantList != null) && (m_hiDpiVariantList.size() > 0)) {
+            handleHiDpiVariants(cms, imageRes, m_scaler, scaledImage, originalScaler);
+        }
+        return scaledImage;
+    }
+
+    /**
+     * Initializes the images scaler used for creating the scaled image bean.<p>
+     *
+     * @param originalScaler a scaler that contains the original image dimensions
+     * @param scaleParams optional scaler parameters for cropping
+     */
+    private void initScaler(CmsImageScaler originalScaler, String scaleParams) {
+
+        int m_width = m_scaler.getWidth();
+        int m_height = m_scaler.getHeight();
+
+        if ((scaleParams != null) && !"undefined".equals(scaleParams)) {
+            CmsImageScaler cropScaler = null;
+            // use cropped image as a base for scaling
+            cropScaler = new CmsImageScaler(scaleParams);
+            if (m_scaler.getType() == 5) {
+                // must reset height / width parameters in crop scaler for type 5
+                cropScaler.setWidth(cropScaler.getCropWidth());
+                cropScaler.setHeight(cropScaler.getCropHeight());
+            }
+            m_scaler = cropScaler.getCropScaler(m_scaler);
+            m_width = m_scaler.getWidth();
+            m_height = m_scaler.getHeight();
+        }
+
+        // If either width or height is not set, the CmsImageScaler will have a problem. So the
+        // missing dimension is calculated with the given dimension and the original image's
+        // aspect ratio (or the respective crop aspect ratio).
+        if ((m_width <= 0) || (m_height <= 0)) {
+            float ratio;
+            // use the original width/height or the crop with/height for aspect ratio calculation
+            if (!m_scaler.isCropping()) {
+                ratio = (float)originalScaler.getWidth() / (float)originalScaler.getHeight();
+            } else {
+                ratio = (float)m_scaler.getCropWidth() / (float)m_scaler.getCropHeight();
+            }
+            if (m_width <= 0) {
+                // width is not set, calculate it with the given height and the original/crop aspect ratio
+                m_width = Math.round(m_height * ratio);
+                m_scaler.setWidth(m_width);
+            } else if (m_height <= 0) {
+                // height is not set, calculate it with the given width and the original/crop aspect ratio
+                m_height = Math.round(m_width / ratio);
+                m_scaler.setHeight(m_height);
+            }
+        }
+
+        // calculate target scale dimensions (if required)
+        if (((m_scaler.getHeight() <= 0) || (m_scaler.getWidth() <= 0))
+            || ((m_scaler.getType() == 5) && m_scaler.isValid() && !m_scaler.isCropping())) {
+            // read the image properties for the selected resource
+            if (originalScaler.isValid()) {
+                m_scaler = originalScaler.getReScaler(m_scaler);
+            }
+        }
+    }
+
+}

--- a/src/org/opencms/jsp/util/CmsJspImageBean.java
+++ b/src/org/opencms/jsp/util/CmsJspImageBean.java
@@ -1,0 +1,95 @@
+
+package org.opencms.jsp.util;
+
+import org.opencms.loader.CmsImageScaler;
+
+/**
+ * Bean containing image information for the use in JSP (e.g. formatters)
+ */
+public class CmsJspImageBean {
+
+    /** The image URL */
+    private String m_srcUrl;
+
+    /** The image's width in pixels */
+    private int m_width;
+
+    /** The image's height in pixels */
+    private int m_height;
+
+    /** The CmsImageScaler that was used to create this image */
+    private CmsImageScaler m_scaler;
+
+    /**
+     * Returns the image's height
+     * @return height in pixels
+     */
+    public int getHeight() {
+
+        return m_height;
+    }
+
+    /**
+     * Returns the image scaler that was used to create this image. May be used to access image scaler properties in JSP.
+     * @return the image scaler that was used to create this image
+     */
+    public CmsImageScaler getScaler() {
+
+        return m_scaler;
+    }
+
+    /**
+     * Returns the image URL that may be used in img or picture tags
+     * @return the image URL
+     */
+    public String getSrcUrl() {
+
+        return m_srcUrl;
+    }
+
+    /**
+     * Returns the image's width
+     * @return width in pixels
+     */
+    public int getWidth() {
+
+        return m_width;
+    }
+
+    /**
+     * Sets the image's height
+     * @param height  the image's width in pixels
+     */
+    public void setHeight(int height) {
+
+        m_height = height;
+    }
+
+    /**
+     * Sets the image scaler that was used to create this image.
+     * @param scaler the image scaler that was used to create this image.
+     */
+    public void setScaler(CmsImageScaler scaler) {
+
+        m_scaler = scaler;
+    }
+
+    /**
+     * Sets the image URL
+     * @param srcUrl the image URL
+     */
+    public void setSrcUrl(String srcUrl) {
+
+        m_srcUrl = srcUrl;
+    }
+
+    /**
+     * Sets the image's width
+     * @param width  the image's width in pixels
+     */
+    public void setWidth(int width) {
+
+        m_width = width;
+    }
+
+}

--- a/src/org/opencms/jsp/util/CmsJspScaledImageBean.java
+++ b/src/org/opencms/jsp/util/CmsJspScaledImageBean.java
@@ -1,0 +1,47 @@
+
+package org.opencms.jsp.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Bean extending the CmsJspImageBean with an additional Map containing hi-DPI variants of the same image.
+ */
+public class CmsJspScaledImageBean extends CmsJspImageBean {
+
+    /**
+     * Internal Map used to store the hi-DPI variants of the image.
+     * <ul>
+     *   <li>key: the variant multiplier, e.g. "2x" (the common retina multiplier)</li>
+     *   <li>value: a CmsJspImageBean representing the hi-DPI variant</li>
+     * </ul>
+     */
+    private Map<String, CmsJspImageBean> m_hiDpiImages;
+
+    /**
+     * adds a CmsJspImageBean as hi-DPI variant to this image
+     * @param factor the variant multiplier, e.g. "2x" (the common retina multiplier)
+     * @param image the image to be used for this variant
+     */
+    public void addHiDpiImage(String factor, CmsJspImageBean image) {
+
+        if (m_hiDpiImages == null) {
+            m_hiDpiImages = new HashMap<>();
+        }
+        m_hiDpiImages.put(factor, image);
+    }
+
+    /**
+     * Returns the map containing all hi-DPI variants of this image.
+     * @return Map containing the hi-DPI variants of the image.
+     * <ul>
+     *   <li>key: the variant multiplier, e.g. "2x" (the common retina multiplier)</li>
+     *   <li>value: a CmsJspImageBean representing the hi-DPI variant</li>
+     * </ul>
+     */
+    public Map<String, CmsJspImageBean> getHiDpiImages() {
+
+        return m_hiDpiImages;
+    }
+
+}

--- a/webapp/WEB-INF/opencms.tld
+++ b/webapp/WEB-INF/opencms.tld
@@ -1700,6 +1700,238 @@
         </attribute>                         
     </tag>
 
+    <!-- scaleImage -->
+    <tag>
+        <description><![CDATA[
+			This tag allows using the OpenCms native image scaling mechanism.
+			It generates a ScaledImage bean that can be used to include the selected image, adding the
+			required image scaling parameters.<br/><br/>
+			The following image formats are supported: BMP, GIF, JPEG, PNG, PNM, TIFF.
+			<em>
+			  Note: Picture scaling is by default only enabled for target size with width and height &lt;=1500.
+			  The size can be changed in the image scaler configuration in the file <code>opencms-vfs.xml</code> in the body of the tag <code>&lt;loader&gt;</code>.
+			  Also other options for the image scaler are set there.
+			  <br/><br/>
+			  This tag is an alternative to the OpenCms standard tag cms:img, providing more felxibility by not
+			  generating any output but providing a bean that may be used to generate any output needed. This way you
+			  can use scaled images for
+			  <ul>
+				<li>The standard img-Tag</li>
+				<li>The more modern picture-Tag with multiple sources for responsive design</li>
+				<li>Background-Image integration</li>
+			  </ul>
+			</em>
+		]]></description>
+        <name>scaleImage</name>
+        <tag-class>org.opencms.jsp.CmsJspTagScaleImage</tag-class>
+        <body-content>JSP</body-content>
+        <variable>
+            <description>Bean containing the scaled image.</description>
+            <name-from-attribute>var</name-from-attribute>
+            <variable-class>org.opencms.jsp.util.CmsJspScaledImageBean</variable-class>
+            <declare>true</declare>
+            <scope>AT_BEGIN</scope>
+        </variable>
+        <!-- These attributes are used to control the image scaling process: -->
+        <attribute>
+            <description><![CDATA[
+			  Uri of the image's source file.</P>
+			  <em>Note: The uri will be adjusted by OpenCms automatically, so do not use <code>&lt;cms:link&gt;</code>.</em>
+			]]></description>
+            <name>src</name>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <description><![CDATA[
+			  A natural number specifying the target width
+			]]></description>
+            <name>width</name>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <description><![CDATA[
+			  A natural number specifying the target height
+			]]></description>
+            <name>height</name>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <description><![CDATA[
+			  <em>Deprecated</em></P>
+			  A natural number specifying the maximal width of an image scaled with <code>scaleType="5"</code>.<BR>
+			  For other scale types the attribute is ignored.
+			]]></description>
+            <name>maxWidth</name>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <description><![CDATA[
+			  <em>Deprecated</em></P>
+			  A natural number specifying the maximal height of an image scaled with <code>scaleType="5"</code>.<BR>
+			  For other scale types the attribute is ignored.
+			]]></description>
+            <name>maxHeight</name>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <description><![CDATA[
+				Set the scale type used for the image.<BR>
+				Possible values are:<dl>
+
+				<dt>0 (default): Scale to exact target size with background padding</dt><dd><ul>
+				<li>enlarge image to fit in target size (if required)
+				<li>reduce image to fit in target size (if required)
+				<li>keep image aspect ratio / proportions intact
+				<li>fill up with bgcolor to reach exact target size
+				<li>fit full image inside target size (only applies if reduced)</ul></dd>
+
+				<dt>1: Thumbnail generation mode (like 0 but no image enlargement)</dt><dd><ul>
+				<li>don't enlarge image
+				<li>reduce image to fit in target size (if required)
+				<li>keep image aspect ratio / proportions intact
+				<li>fill up with bgcolor to reach exact target size
+				<li>fit full image inside target size (only applies if reduced)</ul></dd>
+
+				<dt>2: Scale to exact target size, crop what does not fit</dt><dd><ul>
+				<li>enlarge image to fit in target size (if required)
+				<li>reduce image to fit in target size (if required)
+				<li>keep image aspect ratio / proportions intact
+				<li>fit full image inside target size (crop what does not fit)</ul></dd>
+
+				<dt>3: Scale and keep image proportions, target size variable</dt><dd><ul>
+				<li>enlarge image to fit in target size (if required)
+				<li>reduce image to fit in target size (if required)
+				<li>keep image aspect ratio / proportions intact
+				<li>scaled image will not be padded or cropped, so target size is likely not the exact requested size</ul></dd>
+
+				<dt>4: Don't keep image proportions, use exact target size</dt><dd><ul>
+				<li>enlarge image to fit in target size (if required)
+				<li>reduce image to fit in target size (if required)
+				<li>don't keep image aspect ratio / proportions intact
+				<li>the image will be scaled exactly to the given target size and likely will be loose proportions</ul></dd>
+				</dl>
+				<dt>5: Scale and keep image proportions without enlargement, target size variable with optional max width and height</dt><dd><ul>
+				<li>dont't enlarge image
+				<li>reduce image to fit in target size (if required)
+				<li>keep image aspect ratio / proportions intact
+				<li>best fit into target width / height _OR_ width / maxHeight _OR_ maxWidth / height
+				<li>scaled image will not be padded or cropped, so target size is likely not the exact requested size</ul></dd>
+			]]></description>
+            <name>scaleType</name>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <description><![CDATA[
+			  Specify how the original image is placed if cropped or padded.
+			  The following values are supported:
+			  <DL>
+				<DT><b>0</b> (default)</DT>
+				<DD>center</DD>
+				<DT><b>1</b></DT>
+				<DD>lower left</DD>
+				<DT><b>2</b></DT>
+				<DD>lower right</DD>
+				<DT><b>3</b></DT>
+				<DD>lower middle</DD>
+				<DT><b>4</b></DT>
+				<DD>center left</DD>
+				<DT><b>5</b></DT>
+				<DD>center right</DD>
+				<DT><b>6</b></DT>
+				<DD>upper middle</DD>
+				<DT><b>7</b></DT>
+				<DD>upper left</DD>
+				<DT><b>8</b></DT>
+				<DD>upper right</DD>
+			  </DL>
+			]]></description>
+            <name>scalePosition</name>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <description><![CDATA[
+			  Specify filters applied to the image (and also to a possibly present padding).<BR>
+			  The following values can be given as colon (":") separated list:
+			  <DL>
+				<DT><b>shadow</b></DT>
+				<DD>Adds a shadow effect to the image.</DD>
+				<DT><b>grayscale</b></DT>
+				<DD>Renders the image in grayscale.</DD>
+			  </DL>
+			]]></description>
+            <name>scaleFilter</name>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <description><![CDATA[
+			  An non-negative integer specifying the scale quality in percent.<BR>
+			  Allowed are values between 0 and 100, where 0 is a special value to use the default quality.
+			  The value has only influence on image formats that support a quality setting, e.g. JPEG.</P>
+			  Default: 0.
+			]]></description>
+            <name>scaleQuality</name>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <description><![CDATA[
+			  The color used as backgroud if padding is neccessary.
+			  The following values are supported:
+			  <DL>
+				<DT><b>transparent</b> (default)</DT>
+				<DD>
+				  Transparent background, if supported by the image type, e.g. for PNG.
+				  If transparent background is not supported, e.g. by JPEG, the value defaults to white (FFFFFF).
+				</DD>
+				<DT><b>000000 - FFFFFF</b></DT>
+				<DD>Hexadecimal RGB color code.</DD>
+			  </DT>
+			]]></description>
+            <name>scaleColor</name>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <description><![CDATA[
+			  Set the image processing mode.<BR>
+			  The following values are supported:
+			  <DL>
+				<DT><b>0</b> (default)</DT>
+				<DD>
+				  <em>Quality.</em>
+				  Best possible image processing. Might be slow.
+				</DD>
+				<DT><b>1</b></DT>
+				<DD>
+				  <em>Medium.</em>
+				  Use default JVM settings. Almost as slow as quality mode. Not recommended.
+				</DD>
+				<DT><b>2</b></DT>
+				<DD>
+				  <em>Speed.</em>
+				  Fast image processing. But quality might be not as good as in quality mode.<BR>
+				  The setting is recommended for thumbnail generation.
+				</DD>
+			]]></description>
+            <name>scaleRendermode</name>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <description><![CDATA[
+			  Optional comma separated list of hi DPI veariants to produce, e.g. "1.3x,1.5x,2x,3x". If you only
+			  need the "retina" variant, use "2x". Hi DPI variants may be found in the resulting ScaledImageBean in
+			  the map "hiDpiImages".
+			]]></description>
+            <name>hiDpiVariants</name>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+        <attribute>
+            <description><![CDATA[
+				The name of the variable used to store the resulting ScaledImage bean
+			]]></description>
+            <name>var</name>
+            <rtexprvalue>true</rtexprvalue>
+        </attribute>
+    </tag>
+
     <tag>
         <description><![CDATA[
             This tag can be used to write JSP code from a JSP to files in the static export.</P>


### PR DESCRIPTION
As requested by Alexander Kandzior this is the integration of our scaleImage tag to the OpenCms standard tag library. It's similar to the standard cms:img tag, but it doesn't write to jsp out. Instead a bean with all image information for the scaled image (and possible Hi-DPI variants) is created. JavaDoc is contained, if any additional information is required, I'll provide it. I think a usage sample would make sense, please let me know how that could be integrated in the OpenCms documentation.