### PR TITLE
CmsXmlContent.addValue: Optimized handling of choice elements

### DIFF
--- a/src/org/opencms/xml/content/CmsXmlContent.java
+++ b/src/org/opencms/xml/content/CmsXmlContent.java
@@ -266,106 +266,101 @@ public class CmsXmlContent extends A_CmsXmlDocument {
             contentDefinition = m_contentDefinition;
         }
 
-        // read the XML siblings from the parent node
-        List<Element> siblings = CmsXmlGenericWrapper.elements(parentElement, elementName);
-
         int insertIndex;
 
         if (contentDefinition.getChoiceMaxOccurs() > 0) {
-            // for a choice sequence we do not check the index position, we rather do a full XML validation afterwards
+            // for a choice sequence with maxOccurs we do not check the index position, we rather check if maxOccurs has already been hit
+            List<?> choiceSiblings = parentElement.content();
+            int numSiblings = choiceSiblings != null ? choiceSiblings.size() : 0;
 
-            insertIndex = index;
-        } else if (siblings.size() > 0) {
-            // we want to add an element to a sequence, and there are elements already of the same type
-
-            if (siblings.size() >= type.getMaxOccurs()) {
-                // must not allow adding an element if max occurs would be violated
-                throw new CmsRuntimeException(
-                    Messages.get().container(
-                        Messages.ERR_XMLCONTENT_ELEM_MAXOCCURS_2,
-                        elementName,
-                        new Integer(type.getMaxOccurs())));
-            }
-
-            if (index > siblings.size()) {
-                // index position behind last element of the list
-                throw new CmsRuntimeException(
-                    Messages.get().container(
-                        Messages.ERR_XMLCONTENT_ADD_ELEM_INVALID_IDX_3,
-                        new Integer(index),
-                        new Integer(siblings.size())));
-            }
-
-            // check for offset required to append beyond last position
-            int offset = (index == siblings.size()) ? 1 : 0;
-            // get the element from the parent at the selected position
-            Element sibling = siblings.get(index - offset);
-            // check position of the node in the parent node content
-            insertIndex = sibling.getParent().content().indexOf(sibling) + offset;
-        } else {
-            // we want to add an element to a sequence, but there are no elements of the same type yet
-
-            if (index > 0) {
-                // since the element does not occur, index must be 0
-                throw new CmsRuntimeException(
-                    Messages.get().container(
-                        Messages.ERR_XMLCONTENT_ADD_ELEM_INVALID_IDX_2,
-                        new Integer(index),
-                        elementName));
-            }
-
-            // check where in the type sequence the type should appear
-            int typeIndex = contentDefinition.getTypeSequence().indexOf(type);
-            if (typeIndex == 0) {
-                // this is the first type, so we just add at the very first position
-                insertIndex = 0;
-            } else {
-
-                // create a list of all element names that should occur before the selected type
-                List<String> previousTypeNames = new ArrayList<String>();
-                for (int i = 0; i < typeIndex; i++) {
-                    I_CmsXmlSchemaType t = contentDefinition.getTypeSequence().get(i);
-                    previousTypeNames.add(t.getName());
-                }
-
-                // iterate all elements of the parent node
-                Iterator<Node> i = CmsXmlGenericWrapper.content(parentElement).iterator();
-                int pos = 0;
-                while (i.hasNext()) {
-                    Node node = i.next();
-                    if (node instanceof Element) {
-                        if (!previousTypeNames.contains(node.getName())) {
-                            // the element name is NOT in the list of names that occurs before the selected type,
-                            // so it must be an element that occurs AFTER the type
-                            break;
-                        }
-                    }
-                    pos++;
-                }
-                insertIndex = pos;
-            }
-        }
-
-        I_CmsXmlContentValue newValue;
-        if (contentDefinition.getChoiceMaxOccurs() > 0) {
-            // for a choice we do a full XML validation
-            try {
-                // append the new element at the calculated position
-                newValue = addValue(cms, parentElement, type, locale, insertIndex);
-                // validate the XML structure to see if the index position was valid
-                CmsXmlUtils.validateXmlStructure(m_document, m_encoding, new CmsXmlEntityResolver(cms));
-            } catch (Exception e) {
+            if (numSiblings >= contentDefinition.getChoiceMaxOccurs()) {
                 throw new CmsRuntimeException(
                     Messages.get().container(
                         Messages.ERR_XMLCONTENT_ADD_ELEM_INVALID_IDX_CHOICE_3,
-                        new Integer(insertIndex),
+                        new Integer(index),
                         elementName,
                         parentElement.getUniquePath()));
             }
+            insertIndex = index;
+
         } else {
-            // just append the new element at the calculated position
-            newValue = addValue(cms, parentElement, type, locale, insertIndex);
+            // read the XML siblings from the parent node
+            List<Element> siblings = CmsXmlGenericWrapper.elements(parentElement, elementName);
+
+            if (siblings.size() > 0) {
+                // we want to add an element to a sequence, and there are elements already of the same type
+
+                if (siblings.size() >= type.getMaxOccurs()) {
+                    // must not allow adding an element if max occurs would be violated
+                    throw new CmsRuntimeException(
+                        Messages.get().container(
+                            Messages.ERR_XMLCONTENT_ELEM_MAXOCCURS_2,
+                            elementName,
+                            new Integer(type.getMaxOccurs())));
+                }
+
+                if (index > siblings.size()) {
+                    // index position behind last element of the list
+                    throw new CmsRuntimeException(
+                        Messages.get().container(
+                            Messages.ERR_XMLCONTENT_ADD_ELEM_INVALID_IDX_3,
+                            new Integer(index),
+                            new Integer(siblings.size())));
+                }
+
+                // check for offset required to append beyond last position
+                int offset = (index == siblings.size()) ? 1 : 0;
+                // get the element from the parent at the selected position
+                Element sibling = siblings.get(index - offset);
+                // check position of the node in the parent node content
+                insertIndex = sibling.getParent().content().indexOf(sibling) + offset;
+            } else {
+                // we want to add an element to a sequence, but there are no elements of the same type yet
+
+                if (index > 0) {
+                    // since the element does not occur, index must be 0
+                    throw new CmsRuntimeException(
+                        Messages.get().container(
+                            Messages.ERR_XMLCONTENT_ADD_ELEM_INVALID_IDX_2,
+                            new Integer(index),
+                            elementName));
+                }
+
+                // check where in the type sequence the type should appear
+                int typeIndex = contentDefinition.getTypeSequence().indexOf(type);
+                if (typeIndex == 0) {
+                    // this is the first type, so we just add at the very first position
+                    insertIndex = 0;
+                } else {
+
+                    // create a list of all element names that should occur before the selected type
+                    List<String> previousTypeNames = new ArrayList<String>();
+                    for (int i = 0; i < typeIndex; i++) {
+                        I_CmsXmlSchemaType t = contentDefinition.getTypeSequence().get(i);
+                        previousTypeNames.add(t.getName());
+                    }
+
+                    // iterate all elements of the parent node
+                    Iterator<Node> i = CmsXmlGenericWrapper.content(parentElement).iterator();
+                    int pos = 0;
+                    while (i.hasNext()) {
+                        Node node = i.next();
+                        if (node instanceof Element) {
+                            if (!previousTypeNames.contains(node.getName())) {
+                                // the element name is NOT in the list of names that occurs before the selected type,
+                                // so it must be an element that occurs AFTER the type
+                                break;
+                            }
+                        }
+                        pos++;
+                    }
+                    insertIndex = pos;
+                }
+            }
         }
+
+        // just append the new element at the calculated position
+        I_CmsXmlContentValue newValue = addValue(cms, parentElement, type, locale, insertIndex);
 
         // re-initialize this XML content
         initDocument(m_document, m_encoding, m_contentDefinition);


### PR DESCRIPTION
OpenCms has a performance issue with XML content when it comes to handling choice elements with maxOccurs greater than Zero. Actually the performance issues stem from validating XML content with Apache Xerces, see
- https://issues.apache.org/jira/browse/XERCESJ-1227
- https://issues.apache.org/jira/browse/XERCESJ-1580
- http://stackoverflow.com/questions/13879812/xsdmaxoccurs-specify-large-value-java-lang-outofmemoryerror-jav
- http://www-01.ibm.com/support/docview.wss?uid=swg21296034

When content is saved in OpenCms, the method CmsXmlContent.addValue is called for all content fields. All fields that have been added using choice fields with maxOccurs lead to a full XML validation to check if the maxOccurs value has been exceeded and if so an error is reported. So depending on the content's structure there may be a lot of full XML validations that may be quite slow due to the Xerces problems.

It's not necessary to use XML validation to check if maxOccurs has been exceeded. This pull request removes the XML validation and replaces it with counting the children of the parent node. If the number of children reaches the maxOccurs value, the same error is reported as before.

The file diff on GitHub looks much worse than it actually is. There's not so many changes, see attached diff with whitespace ignored.

![cmsxmlcontent-diff](https://cloud.githubusercontent.com/assets/5979193/18662656/94ff6b6e-7f1b-11e6-9465-4852f03e44a0.png)
