### PR TITLE
CmsMessageService: force encoding

### DIFF
--- a/src/org/opencms/gwt/CmsMessagesService.java
+++ b/src/org/opencms/gwt/CmsMessagesService.java
@@ -41,6 +41,7 @@ import javax.servlet.ServletResponse;
  * Exports the register client messages into a single JavaScript resource.<p>
  */
 public class CmsMessagesService extends CmsGwtService {
+    private static final String DEFAULT_CHARACTER_ENCODING="ISO-8859-1";
 
     /** The serial version id. */
     private static final long serialVersionUID = 3072608993796119377L;
@@ -64,7 +65,21 @@ public class CmsMessagesService extends CmsGwtService {
     public void service(ServletRequest request, ServletResponse response) throws IOException {
 
         try {
-            response.setCharacterEncoding(request.getCharacterEncoding());
+            String characterEncoding = request.getCharacterEncoding();
+            if (null == characterEncoding) {
+                // If the response's character encoding has not been specified, update it to
+                // the default ISO-8859-1 to avoid ambiguous interpretations of the Servlet
+                // spec from different servlet containers.
+                // This complies with the Servlet spec.
+                // See for example the "Java Servlet Specification Version 3.0":
+                // "Servlets should set the locale and the character encoding of a response.
+                // [...]
+                // If the servlet does not specify a character encoding before the getWriter
+                // method of the ServletResponse interface is called or the response is committed,
+                // the default ISO-8859-1 is used."
+                characterEncoding = DEFAULT_CHARACTER_ENCODING;
+            }
+            response.setCharacterEncoding(characterEncoding);
             response.setContentType("text/javascript");
             Locale locale;
             String localeString = request.getParameter(CmsLocaleManager.PARAMETER_LOCALE);

--- a/src/org/opencms/gwt/CmsMessagesService.java
+++ b/src/org/opencms/gwt/CmsMessagesService.java
@@ -41,7 +41,6 @@ import javax.servlet.ServletResponse;
  * Exports the register client messages into a single JavaScript resource.<p>
  */
 public class CmsMessagesService extends CmsGwtService {
-    private static final String DEFAULT_CHARACTER_ENCODING="ISO-8859-1";
 
     /** The serial version id. */
     private static final long serialVersionUID = 3072608993796119377L;
@@ -65,20 +64,18 @@ public class CmsMessagesService extends CmsGwtService {
     public void service(ServletRequest request, ServletResponse response) throws IOException {
 
         try {
-            String characterEncoding = request.getCharacterEncoding();
-            if (null == characterEncoding) {
-                // If the response's character encoding has not been specified, update it to
-                // the default ISO-8859-1 to avoid ambiguous interpretations of the Servlet
-                // spec from different servlet containers.
-                // This complies with the Servlet spec.
-                // See for example the "Java Servlet Specification Version 3.0":
-                // "Servlets should set the locale and the character encoding of a response.
-                // [...]
-                // If the servlet does not specify a character encoding before the getWriter
-                // method of the ServletResponse interface is called or the response is committed,
-                // the default ISO-8859-1 is used."
-                characterEncoding = DEFAULT_CHARACTER_ENCODING;
-            }
+            // Set response's character encoding to the default(*) to avoid ambiguous
+            // interpretations of the Servlet spec from different servlet containers.
+            // This complies with the Servlet spec.
+            // See for example the "Java Servlet Specification Version 3.0":
+            // "Servlets should set the locale and the character encoding of a response.
+            // [...]
+            // If the servlet does not specify a character encoding before the getWriter
+            // method of the ServletResponse interface is called or the response is committed,
+            // the default ISO-8859-1 is used."
+            // (*): the OpenCms configured encoding (defaulting to UTF-8) is favoured over
+            // ISO-8859-1 to allow for a wider charset support.
+            String characterEncoding = OpenCms.getSystemInfo().getDefaultEncoding();
             response.setCharacterEncoding(characterEncoding);
             response.setContentType("text/javascript");
             Locale locale;


### PR DESCRIPTION
to satisfy the Servlet spec requirement that containers must communicate the character encoding used for the servlet response's writer to the client