### PR TITLE
Changed message if deleting resource is not allowed because of broken links

### DIFF
--- a/src/org/opencms/ui/dialogs/CmsDeleteDialog.html
+++ b/src/org/opencms/ui/dialogs/CmsDeleteDialog.html
@@ -11,7 +11,7 @@
 						<v-panel size-full scrollable="true" :expand>
 								<v-vertical-layout _id="m_resourceBox"  style-name="o-reduced-margin o-reduced-spacing" spacing margin />
 						</v-panel>
-						<v-label>%(key.GUI_DELETE_MULTI_CONFIRMATION_0)</v-label>
+						<v-label _id="m_deleteResource" />
 					</v-vertical-layout>
 			</content>
 			<buttons>

--- a/src/org/opencms/ui/dialogs/CmsDeleteDialog.java
+++ b/src/org/opencms/ui/dialogs/CmsDeleteDialog.java
@@ -82,7 +82,10 @@ public class CmsDeleteDialog extends CmsBasicDialog {
     private VerticalLayout m_resourceBox;
 
     // private AbstractComponent m_container;
-
+    
+    /** Message if deleting resources is allowed or not */
+    private Label m_deleteResource;
+    
     /** Label for the links. */
     private Label m_linksLabel;
 
@@ -132,6 +135,8 @@ public class CmsDeleteDialog extends CmsBasicDialog {
             || OpenCms.getRoleManager().hasRole(cms, CmsRole.VFS_MANAGER);
         try {
             Multimap<CmsResource, CmsResource> brokenLinks = getBrokenLinks(cms, m_context.getResources());
+            m_deleteResource.setValue(
+                CmsVaadinUtils.getMessageText(org.opencms.workplace.commons.Messages.GUI_DELETE_MULTI_CONFIRMATION_0));
             if (brokenLinks.isEmpty()) {
                 m_linksLabel.setVisible(false);
                 String noLinksBroken = CmsVaadinUtils.getMessageText(
@@ -139,6 +144,9 @@ public class CmsDeleteDialog extends CmsBasicDialog {
                 m_resourceBox.addComponent(new Label(noLinksBroken));
             } else {
                 if (!canIgnoreBrokenLinks) {
+                    m_deleteResource.setValue(
+                        CmsVaadinUtils.getMessageText(
+                            org.opencms.workplace.commons.Messages.GUI_DELETE_RELATIONS_NOT_ALLOWED_0));
                     m_okButton.setVisible(false);
                 }
                 for (CmsResource source : brokenLinks.keySet()) {


### PR DESCRIPTION
When you are not allowed to delete resources because of broken links the dialog shows the message "Really delete selected resources?" anyway. In the case you are not allowed to delete I changed the message to "You are not allowed to delete the selected resources since that would break one or more relations.".