### PR TITLE
CmsShell: Fix parsing of command line

### DIFF
--- a/modules/org.opencms.locale.de/resources/system/workplace/locales/de/messages/org/opencms/main/messages_de.properties
+++ b/modules/org.opencms.locale.de/resources/system/workplace/locales/de/messages/org/opencms/main/messages_de.properties
@@ -38,6 +38,7 @@ GUI_SHELL_ECHO_ON_0                               =Echo ist nun eingeschaltet.
 GUI_SHELL_ECHO_OFF_0                              =Echo ist nun ausgeschaltet.
 GUI_SHELL_ERR_ADDITIONAL_COMMANDS_1		  =Ungültiger zusätzlicher Kommandoparameter: "{0}"
 GUI_SHELL_ERR_SCRIPTFILE_1                        =Probleme beim Lesen der Script Datei "{0}", benutze die Standardeingabe (STDIN).
+GUI_SHELL_ESCAPE_SEQUENCES_NOT_SUPPORTED_0        =Escape-Zeichnen (z.B. Pfeilhochtaste, Pfeilruntertaste) nicht unterstützt. Zeile ignoriert.
 GUI_SHELL_EXEC_METHOD_1                           =Fehler beim Aufruf der Methode "{0}".
 # Externalized even if not locale-dependant: Just to have the layout overview here (compare with lengths)
 GUI_SHELL_GOODBYE_0                               =Auf Wiedersehen!

--- a/modules/org.opencms.locale.es/resources/system/workplace/locales/es/messages/org/opencms/main/messages_es.properties
+++ b/modules/org.opencms.locale.es/resources/system/workplace/locales/es/messages/org/opencms/main/messages_es.properties
@@ -30,6 +30,7 @@ GUI_SHELL_CURRENT_FOLDER_1                        =La carpeta actual es "{0}".
 GUI_SHELL_ECHO_ON_0                               =Echo está activado.
 GUI_SHELL_ECHO_OFF_0                              =Echo está desactivado.
 GUI_SHELL_ERR_SCRIPTFILE_1                        =Problemas leyendo el fichero de script "{0}", utilizando SDTIN en su lugar.
+GUI_SHELL_ESCAPE_SEQUENCES_NOT_SUPPORTED_0        =Las secuencias de escape (p.ej. arriba, abajo) no están soportadas. Comando ignorado.
 GUI_SHELL_EXEC_METHOD_1                           =Excepción llamando al método "{0}".
 GUI_SHELL_GOODBYE_0                               =¡Adiós!
 GUI_SHELL_HR_0                                    =-----------------------------------------------------------------------

--- a/src/org/opencms/main/Messages.java
+++ b/src/org/opencms/main/Messages.java
@@ -196,6 +196,9 @@ public final class Messages extends A_CmsMessageBundle {
     public static final String GUI_SHELL_IMPORTEXPORT_MODULE_HANDLER_NAME_1 = "GUI_SHELL_IMPORTEXPORT_MODULE_HANDLER_NAME_1";
 
     /** Message constant for key in the resource bundle. */
+    public static final String GUI_SHELL_ESCAPE_SEQUENCES_NOT_SUPPORTED_0 = "GUI_SHELL_ESCAPE_SEQUENCES_NOT_SUPPORTED_0";
+
+    /** Message constant for key in the resource bundle. */
     public static final String GUI_SHELL_LIST_MODULES_1 = "GUI_SHELL_LIST_MODULES_1";
 
     /** Message constant for key in the resource bundle. */

--- a/src/org/opencms/main/messages.properties
+++ b/src/org/opencms/main/messages.properties
@@ -50,6 +50,7 @@ GUI_SHELL_HELP3_0                                 =help {string}     Shows the s
 GUI_SHELL_HELP4_0                                 =exit or quit      Leaves this OpenCms Shell.
 GUI_SHELL_IMPORT_TEMP_PROJECT_NAME_0              =A temporary project for a system update.
 GUI_SHELL_IMPORTEXPORT_MODULE_HANDLER_NAME_1      =Module export of {0}.
+GUI_SHELL_ESCAPE_SEQUENCES_NOT_SUPPORTED_0        =Escape sequences not supported (e.g. up, down, etc). Command ignored.
 GUI_SHELL_LIST_MODULES_1                          =There are currently {0} modules installed:
 GUI_SHELL_LOCALES_AVAILABLE_0                     =The following values may be used for method "setLocale(String)": 
 GUI_SHELL_LOGIN_1                                 =You are now logged in as user "{0}".
@@ -73,7 +74,7 @@ GUI_SHELL_FOLDER_ALREADY_EXISTS_1                   =The folder "{0}" already ex
 GUI_SOLR_ERROR_HTML_1                             =<?xml version="1.0" ?><!DOCTYPE html><html><head><title>SolrError</title></head><body><div><h4>Solr Error</h4><div>{0}</div></body></html>
 GUI_SOLR_UNEXPECTED_ERROR_0                       =<strong>An Unexpected error occurred while performing a Solr query.</strong><br/>
 GUI_SOLR_INDEX_NOT_FOUND_1                        =No Solr index named: <strong>{0}</strong> configured. <br/><i>You can request a certain Solr index with the request parameter <code>'core=<INDEX_NAME>'</code>. If only one Solr index is configured in the <code>'opencms-search.xml'</code> OpenCms tries to use that one as fallback.</i>
-GUI_SOLR_NOT_LOGGED_IN_0                          =Not logged into OpenCms, please log in before sending requests to OpenCms Solr-Hnalder.
+GUI_SOLR_NOT_LOGGED_IN_0                          =Not logged into OpenCms, please log in before sending requests to OpenCms Solr-Handler.
 
 INIT_DOT_0                                        =.
 INIT_ERR_LOAD_HTML_PROPERTY_FILE_1                =Could not load {0}


### PR DESCRIPTION
Fixes #500

Detailed changes:
- Ignore `null` tokens.
- Includes i18n for `en`,`de` and `es`.
- Includes unit test.