### PR TITLE
gwt RPC: handle missing explorer type settings gracefully

### DIFF
--- a/src/org/opencms/gwt/CmsVfsService.java
+++ b/src/org/opencms/gwt/CmsVfsService.java
@@ -28,6 +28,7 @@
 package org.opencms.gwt;
 
 import org.opencms.ade.galleries.CmsPreviewService;
+import org.opencms.configuration.CmsConfigurationException;
 import org.opencms.file.CmsFile;
 import org.opencms.file.CmsObject;
 import org.opencms.file.CmsProject;
@@ -74,6 +75,7 @@ import org.opencms.gwt.shared.property.CmsPropertiesBean;
 import org.opencms.gwt.shared.property.CmsPropertyChangeSet;
 import org.opencms.gwt.shared.rpc.I_CmsVfsService;
 import org.opencms.i18n.CmsLocaleManager;
+import org.opencms.i18n.CmsMessageContainer;
 import org.opencms.i18n.CmsMessages;
 import org.opencms.json.JSONObject;
 import org.opencms.jsp.CmsJspNavBuilder;
@@ -97,6 +99,7 @@ import org.opencms.util.CmsUUID;
 import org.opencms.widgets.dataview.I_CmsDataView;
 import org.opencms.widgets.dataview.I_CmsDataViewItem;
 import org.opencms.workplace.comparison.CmsHistoryListUtil;
+import org.opencms.workplace.explorer.CmsExplorerTypeSettings;
 import org.opencms.workplace.explorer.CmsResourceUtil;
 import org.opencms.xml.containerpage.CmsXmlContainerPageFactory;
 import org.opencms.xml.content.CmsXmlContentFactory;
@@ -126,6 +129,7 @@ import com.google.common.collect.Multimap;
  *
  * @since 8.0.0
  */
+@SuppressWarnings("GwtServiceNotRegistered")
 public class CmsVfsService extends CmsGwtService implements I_CmsVfsService {
 
     /** The static log object for this class. */
@@ -347,6 +351,15 @@ public class CmsVfsService extends CmsGwtService implements I_CmsVfsService {
         }
         listInfo.setIsFolder(Boolean.valueOf(resource.isFolder()));
         String resTypeName = OpenCms.getResourceManager().getResourceType(resource.getTypeId()).getTypeName();
+        CmsExplorerTypeSettings cmsExplorerTypeSettings = OpenCms.getWorkplaceManager().getExplorerTypeSetting(resTypeName);
+        if (null == cmsExplorerTypeSettings) {
+            CmsMessageContainer errMsg = Messages.get().container(
+                    Messages.ERR_EXPLORER_TYPE_SETTINGS_FOR_RESOURCE_TYPE_NOT_FOUND_3, resource.getRootPath(), resTypeName, resource.getTypeId());
+            // Extended info for the admin
+            LOG.warn(String.format("Explorer type settings for resource \"%s\" of type \"%s\" (%d) not found. (Hint: check your config/opencms-workplace.xml)",
+                    resource.getRootPath(), resTypeName, resource.getTypeId()));
+            throw new CmsConfigurationException(errMsg);
+        }
         String key = OpenCms.getWorkplaceManager().getExplorerTypeSetting(resTypeName).getKey();
         Locale currentLocale = OpenCms.getWorkplaceManager().getWorkplaceLocale(cms);
         CmsMessages messages = OpenCms.getWorkplaceManager().getMessages(currentLocale);

--- a/src/org/opencms/gwt/Messages.java
+++ b/src/org/opencms/gwt/Messages.java
@@ -82,6 +82,9 @@ public final class Messages extends A_CmsMessageBundle {
     public static final String ERR_VALIDATOR_INSTANTIATION_FAILED_1 = "ERR_VALIDATOR_INSTANTIATION_FAILED_1";
 
     /** Message constant for key in the resource bundle. */
+    public static final String ERR_EXPLORER_TYPE_SETTINGS_FOR_RESOURCE_TYPE_NOT_FOUND_3 = "ERR_EXPLORER_TYPE_SETTINGS_FOR_RESOURCE_TYPE_NOT_FOUND_3";
+
+    /** Message constant for key in the resource bundle. */
     public static final String GUI_ALIAS_0 = "GUI_ALIAS_0";
 
     /** Message constant for key in the resource bundle. */

--- a/src/org/opencms/gwt/messages.properties
+++ b/src/org/opencms/gwt/messages.properties
@@ -13,6 +13,7 @@ GUI_NO_PREVIEW_CAN_T_READ_CONTENT_0     =Could not read file content
 ERR_VALIDATOR_INCORRECT_TYPE_1			=The class "{0}" is not a validation service
 ERR_RESOURCE_MODIFIED_AFTER_OPEN_1		=Unable to lock the resource "{0}" because it was modified since you opened it. 
 ERR_VALIDATOR_INSTANTIATION_FAILED_1	=Could not instantiate the validation service "{0}".
+ERR_EXPLORER_TYPE_SETTINGS_FOR_RESOURCE_TYPE_NOT_FOUND_3=Explorer type settings for resource "{0}" of type "{1}" ({2}) not found.
 
 ERR_INSTANTIATION_FAILED_1 				=Could not instantiate the class "{0}".
 ERR_INSTANTIATION_INCORRECT_TYPE_2		=The class "{0}" is not a subclass of "{1}".


### PR DESCRIPTION
OpenCms throws a confusing NPE when trying to open the explorer properties
dialog for a resource whose type settings cannot be found.

This patch displays a more informative message and outputs an informative error
in the logs for the administrator.