### PR TITLE
Handle NPE on invalid formatter configuration

### DIFF
--- a/src/org/opencms/ade/configuration/formatters/CmsFormatterBeanParser.java
+++ b/src/org/opencms/ade/configuration/formatters/CmsFormatterBeanParser.java
@@ -29,6 +29,7 @@ package org.opencms.ade.configuration.formatters;
 
 import org.opencms.ade.configuration.CmsConfigurationReader;
 import org.opencms.ade.configuration.CmsPropertyConfig;
+import org.opencms.configuration.CmsConfigurationException;
 import org.opencms.file.CmsObject;
 import org.opencms.file.CmsResource;
 import org.opencms.file.types.I_CmsResourceType;
@@ -36,6 +37,7 @@ import org.opencms.i18n.CmsLocaleManager;
 import org.opencms.jsp.util.CmsMacroFormatterResolver;
 import org.opencms.main.CmsException;
 import org.opencms.main.CmsLog;
+import org.opencms.main.Messages;
 import org.opencms.main.OpenCms;
 import org.opencms.relations.CmsLink;
 import org.opencms.util.CmsStringUtil;
@@ -360,12 +362,20 @@ public class CmsFormatterBeanParser {
             I_CmsXmlContentValueLocation jspLoc = root.getSubValue(N_JSP);
             CmsXmlVfsFileValue jspValue = (CmsXmlVfsFileValue)(jspLoc.getValue());
             CmsLink link = jspValue.getLink(m_cms);
+
             if (link == null) {
                 // JSP link is not set (for example because the formatter configuration has just been created)
                 LOG.info("JSP link is null in formatter configuration: " + content.getFile().getRootPath());
                 return null;
             }
             CmsUUID jspID = link.getStructureId();
+
+            if (jspID == null) {
+                throw new CmsConfigurationException(Messages.get().container(
+                        Messages.ERR_READ_FORMATTER_CONFIG_4,
+                        new Object[]{link.getUri(), m_niceName, location, "" + m_resourceType}));
+            }
+
             CmsResource formatterRes = m_cms.readResource(jspID);
             m_formatterResource = formatterRes;
             String previewStr = getString(root, N_PREVIEW, "false");

--- a/src/org/opencms/main/Messages.java
+++ b/src/org/opencms/main/Messages.java
@@ -130,6 +130,9 @@ public final class Messages extends A_CmsMessageBundle {
     public static final String ERR_READ_INTERNAL_RESOURCE_1 = "ERR_READ_INTERNAL_RESOURCE_1";
 
     /** Message constant for key in the resource bundle. */
+    public static final String ERR_READ_FORMATTER_CONFIG_4 = "ERR_READ_FORMATTER_CONFIG_4";
+
+    /** Message constant for key in the resource bundle. */
     public static final String ERR_REQUEST_SECURE_RESOURCE_0 = "ERR_REQUEST_SECURE_RESOURCE_0";
 
     /** Message constant for key in the resource bundle. */

--- a/src/org/opencms/main/messages.properties
+++ b/src/org/opencms/main/messages.properties
@@ -23,6 +23,7 @@ ERR_NOT_A_FOLDER_1                                =Not a folder: "{0}".
 ERR_OPENCMS_NOT_INITIALIZED_2                     =HTTP Status {0}\nOpenCms is not properly initialized!\nPlease make sure that the OpenCms setup wizard has been run once and is disabled now.\n{1}
 ERR_PERMALINK_1									  =Error while trying to retrieve the resource with id "{0}".
 ERR_READ_INTERNAL_RESOURCE_1                      =Failed to read resource "{0}". It is only available for internal access operations.
+ERR_READ_FORMATTER_CONFIG_4                       =Invalid jsp "{0}" specified in formatter "{1}" configured in "{2}" for type(s) "{3}".
 ERR_REQUEST_SECURE_RESOURCE_0					  =Resource can only be accessed using the HTTPS secure protocol.
 ERR_SHOW_ERR_HANDLER_RESOURCE_2                   =Error showing error handler resource in "{0}" URI handler for "{1}".
 ERR_UNKNOWN_MODULE_1                              =Unable to export unknown module "{0}".


### PR DESCRIPTION
If a formatter specifies an invalid (e.g. missing) jsp, opencms can throw an
uncontrolled NPE with very little diagnostic information (e.g. on module
import).