### PR TITLE
Can not use Guava versions greater than 20.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -68,7 +68,7 @@ dependencies {
     distribution group: 'com.google.code.findbugs', name: 'jsr305', version: '2.0.1'
     distribution group: 'com.google.errorprone', name: 'error_prone_annotations', version: '2.0.18'
      
-    distribution group: 'com.google.guava', name: 'guava', version: '23.0'
+    distribution group: 'com.google.guava', name: 'guava', version: '20.0'
     distribution group: 'com.google.guava', name: 'guava-gwt', version: '23.0'
     distribution group: 'com.google.gwt', name: 'gwt-servlet', version: '2.8.2'
     distribution group: 'com.google.j2objc', name: 'j2objc-annotations', version: '1.1'


### PR DESCRIPTION
Guava has some big changes since version 21, NoSuchMethodError appears if you are using version 21 or later.
The Guava version that is dependent on Solr7's pom.xml is 14, and the Guava version that is dependent on tika-parsers is version 17.