### PR TITLE
The field id of CmsSolrDocument cannot use type of CmsUUID.

### DIFF
--- a/src/org/opencms/search/solr/CmsSolrDocument.java
+++ b/src/org/opencms/search/solr/CmsSolrDocument.java
@@ -435,7 +435,7 @@ public class CmsSolrDocument implements I_CmsSearchDocument {
      */
     public void setId(CmsUUID structureId) {
 
-        m_doc.addField(CmsSearchField.FIELD_ID, structureId);
+        m_doc.addField(CmsSearchField.FIELD_ID, structureId.toString());
 
     }
 


### PR DESCRIPTION
The field id of CmsSolrDocument cannot use type of CmsUUID, it should be base type String.

Solr 7.4.0 will throw exception like this:
Caused by: org.apache.solr.common.SolrException: Invalid UUID String: 'org.opencms.util.CmsUUID:a4b94fa8-c149-11e6-9510-0242ac11002b'
