### PR TITLE
Fixed an issue where CmsFlexCache is not thread safe.

### DIFF
--- a/src/org/opencms/flex/CmsFlexCacheKey.java
+++ b/src/org/opencms/flex/CmsFlexCacheKey.java
@@ -214,9 +214,6 @@ public class CmsFlexCacheKey {
     /** Cache key variable: The user id. */
     private String m_user;
 
-    /** The cache behaviour description for the resource. */
-    private String m_variation;
-
     /** Resource without online / offline suffix. */
     private String m_actualResource;
 
@@ -240,7 +237,6 @@ public class CmsFlexCacheKey {
 
         m_actualResource = resourcename;
         m_resource = getKeyName(resourcename, online);
-        m_variation = "never";
         m_always = -1;
         m_timeout = -1;
         if (cacheDirectives != null) {
@@ -802,26 +798,6 @@ public class CmsFlexCacheKey {
     protected long getTimeout() {
 
         return m_timeout;
-    }
-
-    /**
-     * Returns the variation.<p>
-     *
-     * @return the variation
-     */
-    protected String getVariation() {
-
-        return m_variation;
-    }
-
-    /**
-     * Sets the variation.<p>
-     *
-     * @param variation the variation to set
-     */
-    protected void setVariation(String variation) {
-
-        m_variation = variation;
     }
 
     /**


### PR DESCRIPTION
_The following texts are translated by Google Translator. If it is not correct, please try to understand. Thank you!_

Fixed an issue where CmsFlexCache was not thread safe.
**1. CmsFlexCache may not be thread safe.**
In the CmsFlexCache class,
CmsFlexCache.putKey(CmsFlexCacheKey key) This method needs to ensure that you do not overwrite existing data in multi-threaded access.
CmsFlexCache.put(CmsFlexCacheKey key, CmsFlexCacheEntry theCacheEntry, String variation) may have the same problem.
So it may be safe to use synchronized to encapsulate it.

**2. Fixed an issue where [VFS target resource "{0}" was already included earlier.].**
This exception does not know under what circumstances it will trigger. Basically impossible to debug. (But after using the code I submitted this time, there is no such problem in the production environment.)

**3. FlexCacheKey should not change "variation" at runtime.**
The FlexCacheKey instance is unique, but it constantly changes the variation property at runtime, which obviously causes problems. Perhaps this is the reason for the second exception above, but it is not certain.

In fact, these three points may be the key to solving the problem. Because I don't know which one is the specific one. But after these few modifications, the problem was solved.

**By the way, the problems actually encountered by my website:**
Because in the actual production environment, due to the large number of user visits on the website, the exception is [VFS target resource "{0}" was already included earlier.] This exception can only be refreshed after the FlexCache is cleared in the background. The page can be solved, sometimes it is necessary to repeat the refresh multiple times. The guess is that when multiple users access a page at the same time, there is a conflict when generating cached data, so this is not caused by thread safety.

**The problem is solved:**
After using the modified code, there is no more abnormality in the actual production environment, even when the user visits the peak period during the day, it has not appeared again. So I think this problem may have been fixed before contributing the modified code.