### PR TITLE
Add feature: cms:headincludes automatically adds the version id to the URI

### DIFF
--- a/src/org/opencms/jsp/CmsJspTagHeadIncludes.java
+++ b/src/org/opencms/jsp/CmsJspTagHeadIncludes.java
@@ -421,7 +421,7 @@ public class CmsJspTagHeadIncludes extends BodyTagSupport implements I_CmsJspTag
             pageContext.getOut().print(
                 "\n<link rel=\"stylesheet\" href=\""
                     + CmsJspTagLink.linkTagAction(cssUri.trim(), req)
-                    + generateReqParams()
+                    + generateReqParams(cms, cssUri.trim())
                     + "\" type=\"text/css\" ");
             if (shouldCloseTags()) {
                 pageContext.getOut().print("/>");
@@ -523,7 +523,7 @@ public class CmsJspTagHeadIncludes extends BodyTagSupport implements I_CmsJspTag
             pageContext.getOut().print(
                 "\n<script type=\"text/javascript\" src=\""
                     + CmsJspTagLink.linkTagAction(jsUri.trim(), req)
-                    + generateReqParams()
+                    + generateReqParams(cms, jsUri.trim())
                     + "\"></script>");
         }
         if (!inlineJS.isEmpty()) {
@@ -651,14 +651,26 @@ public class CmsJspTagHeadIncludes extends BodyTagSupport implements I_CmsJspTag
 
     /**
      * Generates the request parameter string.<p>
+     * @param cms the current cms context
+     * @param target the link that should be calculated, can be relative or absolute
      *
      * @return the request parameter string
      *
      * @throws UnsupportedEncodingException if something goes wrong encoding the request parameters
      */
-    private String generateReqParams() throws UnsupportedEncodingException {
+    private String generateReqParams(CmsObject cms, String target) throws UnsupportedEncodingException {
 
         String params = "";
+        try {
+            // Add the latest release time of the resource
+            // to the URI of the (static) resource
+            // as the version number identifier.
+            CmsResource targetRes = cms.readResource(target);
+            params = "?ver=" + targetRes.getDateLastModified();
+        } catch (CmsException e) {
+            // This should never happen
+        }
+        
         if ((m_parameterMap != null) && !m_parameterMap.isEmpty()) {
             for (Entry<String, String[]> paramEntry : m_parameterMap.entrySet()) {
                 if (paramEntry.getValue() != null) {


### PR DESCRIPTION
**Add feature:** cms:headincludes automatically adds the version identifier of the static resource to the URI.

Cms:headincludes handles two static resources, css and js. If css and js are modified on the server side, it is difficult to ensure that the client gets updates in real time because the URI has not changed and the browser uses the cache.
Therefore, this feature mainly adds the latest release time of the resource to the URI of the static resource as the version identifier.
This ensures that the static resources are retrieved by the client to the latest version in real time after modification.

**Usage:** Actually, no additional code changes are required, because only one default processing item is added to the submitted implementation. So the default usage is fine.

**For example, in apollo-page.jsp:**
```
    <c:set var="theme"><cms:property name="apollo.theme" file="search" default="red" /></c:set>
    <c:choose>
      <c:when test="${fn:endsWith(theme, 'ap-includes.jsp')}">
          <cms:include file="${theme}" />
	  <cms:headincludes type="css" />
      </c:when>
      <c:otherwise>
          <c:if test="${not fn:startsWith(theme, '/')}">
             <c:set var="theme">/system/modules/org.opencms.apollo.theme/resources/css/style-${theme}.min.css</c:set>
          </c:if>
	  <cms:headincludes type="css" defaults="${theme}" />
      </c:otherwise>
    </c:choose>
```


**Finally generate such code:**

```
<link rel="stylesheet" href="/export/system/modules/org.opencms.apollo.theme/resources/css/style-red.min.css?ver=1531211047501" type="text/css" />

<script type="text/javascript" src="/export/system/modules/org.opencms.apollo.theme/resources/js/scripts-all.min.js?ver=1527845258074"></script>
```