### PR TITLE
(Feature Request) Override search dir from system properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1199,6 +1199,12 @@ test {
     systemProperties['test.data.path'] = "${projectDir}/test/data"
     systemProperties['test.webapp.path'] = "${projectDir}/webapp"
     systemProperties['test.build.folder'] =sourceSets.test.output.resourcesDir
+    if (project.hasProperty('solr.solr.home')) {
+        systemProperties['solr.solr.home'] = project.getProperty('solr.solr.home')
+    }
+    if (project.hasProperty('opencms.search.directory')) {
+        systemProperties['opencms.search.directory'] = project.getProperty('opencms.search.directory')
+    }
     maxHeapSize = max_heap_size
     jvmArgs '-XX:MaxPermSize=256m'
     testLogging.showStandardStreams = true
@@ -1225,6 +1231,13 @@ task testSingle(type: Test, dependsOn: [compileTestJava]) {
     systemProperties['test.data.path'] = "${projectDir}/test/data"
     systemProperties['test.webapp.path'] = "${projectDir}/webapp"
     systemProperties['test.build.folder'] =sourceSets.test.output.resourcesDir
+    if (project.hasProperty('solr.solr.home')) {
+        systemProperties['solr.solr.home'] = project.getProperty('solr.solr.home')
+    }
+    if (project.hasProperty('opencms.search.directory')) {
+        systemProperties['opencms.search.directory'] = project.getProperty('opencms.search.directory')
+    }
+    
     maxHeapSize = max_heap_size
     jvmArgs '-XX:MaxPermSize=256m'
     testLogging.showStandardStreams = true

--- a/src/org/opencms/configuration/CmsSearchConfiguration.java
+++ b/src/org/opencms/configuration/CmsSearchConfiguration.java
@@ -90,6 +90,9 @@ public class CmsSearchConfiguration extends A_CmsXmlConfiguration {
     /** The name of the default XML file for this configuration. */
     public static final String DEFAULT_XML_FILE_NAME = "opencms-search.xml";
 
+    /** The system property name for the search directory. */
+    public static final String SEARCH_DIRECTORY_PROPERTY = "opencms.search.directory";
+
     /** Node name constant. */
     public static final String N_ANALYZER = "analyzer";
 
@@ -244,7 +247,7 @@ public class CmsSearchConfiguration extends A_CmsXmlConfiguration {
         digester.addSetNext(XPATH_SEARCH, "setSearchManager");
 
         // directory rule
-        digester.addCallMethod(XPATH_SEARCH + "/" + N_DIRECTORY, "setDirectory", 0);
+        digester.addCallMethod(XPATH_SEARCH + "/" + N_DIRECTORY, "setDirectoryOnlyIfUndefined", 0);
 
         // timeout rule
         digester.addCallMethod(XPATH_SEARCH + "/" + N_TIMEOUT, "setTimeout", 0);

--- a/src/org/opencms/search/Messages.java
+++ b/src/org/opencms/search/Messages.java
@@ -158,6 +158,9 @@ public final class Messages extends A_CmsMessageBundle {
     public static final String ERR_SOLR_SERVER_NOT_CREATED_3 = "ERR_SOLR_SERVER_NOT_CREATED_3";
 
     /** Message constant for key in the resource bundle. */
+    public static final String ERR_SOLR_SERVER_CANNOT_CREATE_DIR_2 = "ERR_SOLR_SERVER_CANNOT_CREATE_DIR_2";
+
+    /** Message constant for key in the resource bundle. */
     public static final String GUI_HELP_BUTTON_BACK_0 = "GUI_HELP_BUTTON_BACK_0";
 
     /** Message constant for key in the resource bundle. */
@@ -353,6 +356,9 @@ public final class Messages extends A_CmsMessageBundle {
     public static final String LOG_PARSE_EXCERPT_LENGTH_FAILED_2 = "LOG_PARSE_EXCERPT_LENGTH_FAILED_2";
 
     /** Message constant for key in the resource bundle. */
+    public static final String LOG_PARSE_DIRECTORY_IGNORED_3 = "LOG_PARSE_DIRECTORY_IGNORED_3";
+
+    /** Message constant for key in the resource bundle. */
     public static final String LOG_PARSE_EXTRACTION_CACHE_AGE_FAILED_2 = "LOG_PARSE_EXTRACTION_CACHE_AGE_FAILED_2";
 
     /** Message constant for key in the resource bundle. */
@@ -407,6 +413,9 @@ public final class Messages extends A_CmsMessageBundle {
 
     /** Message constant for key in the resource bundle. */
     public static final String LOG_SEARCHINDEX_DISABLED_1 = "LOG_SEARCHINDEX_DISABLED_1";
+
+    /** Message constant for key in the resource bundle. */
+    public static final String LOG_SEARCH_SET_DIRECTORY_FROM_SYSPROP_1 = "LOG_SEARCH_SET_DIRECTORY_FROM_SYSPROP_1";
 
     /** Message constant for key in the resource bundle. */
     public static final String LOG_SEARCHING_FAILED_0 = "LOG_SEARCHING_FAILED_0";

--- a/src/org/opencms/search/messages.properties
+++ b/src/org/opencms/search/messages.properties
@@ -36,6 +36,7 @@ ERR_SEARCHINDEX_CREATE_MISSING_NAME_0  =The name of the index must not be empty!
 ERR_SEARCHINDEX_CREATE_INVALID_NAME_1  =The name "{0}" is already used by an existing search index. Choose a unique name for search indices.
 ERR_SOLR_NOT_ENABLED_0                 =Solr is not enabled, please check 'opencms-search.xml'.
 ERR_SOLR_CORE_CONTAINER_NOT_CREATED_1  =The Solr core container could not be created for Solr server with the configuration file: {0}.
+ERR_SOLR_SERVER_CANNOT_CREATE_DIR_2    =Cannot create dir "{0}". Current configuration: "{1}".
 ERR_SOLR_SERVER_NOT_CREATED_3          =Solr Server for index: {0} ({1}) with configuration "{2}" could not be created.
 ERR_SPELLCHECK_CORE_NOT_AVAILABLE_1    =The SOLR spellchecking index is not configured properly. The core "{0}" is missing from the configuration at '/WEB-INF/solr/solr.xml'.
 
@@ -103,6 +104,7 @@ LOG_OI_UPDATE_FINISH_2                 =Finished offline index update with {0} r
 LOG_OI_UPDATE_LONG_2                   =Offline index update with {0} resources already running for {1} msecs.
 LOG_OI_UPDATE_INTERRUPT_0              =Offline index rebuild request send by interrupt.
 LOG_PARSE_EXCERPT_LENGTH_FAILED_2      =Error parsing search index maximum excerpt length value "{0}", using {1} chars.
+LOG_PARSE_DIRECTORY_IGNORED_3          =Not setting search directory because it has been already defined. This can be the case if the system property "-D{0}=..." has been set. Current value "{1}". Ignoring new value "{2}".
 LOG_PARSE_EXTRACTION_CACHE_AGE_FAILED_2=Error parsing search index maximum extraction cache age value "{0}", using {1} hours.
 LOG_PARSE_MAXCOMMIT_FAILED_2           =Error parsing search index maximum number of modifications before a commit is triggered value "{0}", using {1} modifications.
 LOG_PARSE_TIMEOUT_FAILED_2             =Error parsing search index document generation timeout value "{0}", using {1} msecs.
@@ -119,6 +121,7 @@ LOG_RESULT_ITERATION_FAILED_0          =Error during search result iteration.
 LOG_REWRITTEN_QUERY_1                  =Rewritten query: {0}
 LOG_SEARCHINDEX_CREATE_BAD_PROJECT_2   =The project "{0}" configured for search index "{1}" does not exist.
 LOG_SEARCHINDEX_DISABLED_1			   =Search index "{0}" is disabled.
+LOG_SEARCH_SET_DIRECTORY_FROM_SYSPROP_1=Setting OpenCms search directory with system property: "{0}".
 LOG_SEARCHING_FAILED_0                 =Searching failed.
 LOG_SEARCH_PARAMS_2                    =Searching for "{0}" in index "{1}".
 LOG_SEARCH_PRIORITY_TOO_HIGH_2         =Value "{0}" given for search thread priority is too high, setting it to "{1}".


### PR DESCRIPTION
Due to #585, it is convenient for the tests to make the OpenCms "search directory" overridable with a system property in the same way as the solr home directory can currently be overridden with a property `solr.solr.home`.

This PR implements the reading of a new system property `opencms.search.directory` that, if defined, overrides the value of the `<directory>` element in `opencms-search.xml`.