### PR TITLE
Italian locale for the codemirror plugin of tinymce

### DIFF
--- a/modules/org.opencms.base/static/editors/tinymce/jscripts/tinymce/plugins/codemirror/langs/it.js
+++ b/modules/org.opencms.base/static/editors/tinymce/jscripts/tinymce/plugins/codemirror/langs/it.js
@@ -1,0 +1,8 @@
+tinymce.addI18n('it',{
+	'HTML source code': 'Codice sorgente HTML',
+	'Start search': 'Inizia ricerca',
+	'Find next': 'Trova successivo',
+	'Find previous': 'Trova precedente',
+	'Replace': 'Sostituisci',
+	'Replace all': 'Sostituisci tutti'
+});


### PR DESCRIPTION
This fixes an error that pops up in the tinymce editor (missing locale file) when the users' locale is set to italian.