### PR TITLE
fixed bug in flex cache causing concurrent modification exception

### DIFF
--- a/src/org/opencms/flex/CmsFlexCache.java
+++ b/src/org/opencms/flex/CmsFlexCache.java
@@ -168,15 +168,16 @@ public class CmsFlexCache extends Object implements I_CmsEventListener {
             if ((m == null) || (m.size() == 0)) {
                 return true;
             }
-            Collection<I_CmsLruCacheObject> entries = m.values();
-            synchronized (m_variationCache) {
-                for (I_CmsLruCacheObject e : entries) {
-                    m_variationCache.remove(e);
-                }
-                v.m_map.clear();
-                v.m_map = null;
-                v.m_key = null;
+            Iterator<I_CmsLruCacheObject> allEntries = v.m_map.values().iterator();
+            while(allEntries.hasNext()) {
+                I_CmsLruCacheObject nextObject = allEntries.next();
+                allEntries.remove();
+                m_variationCache.remove(nextObject);
             }
+            v.m_map.clear();
+            v.m_map = null;
+            v.m_key = null;
+            
             return true;
         }
     }
@@ -780,7 +781,7 @@ public class CmsFlexCache extends Object implements I_CmsEventListener {
         if (o == null) {
             // No variation map for this resource yet, so create one
             CmsFlexCacheVariation variationMap = new CmsFlexCacheVariation(key);
-            m_keyCache.put(key.getResource(), variationMap);
+            synchronizedCopyMap(m_keyCache).put(key.getResource(), variationMap);
             if (LOG.isDebugEnabled()) {
                 LOG.debug(Messages.get().getBundle().key(Messages.LOG_FLEXCACHE_ADD_KEY_1, key.getResource()));
             }


### PR DESCRIPTION
If you have a lot of files in opencms and the cache key params in opencms-system.xml are too small the flex cache does not contain all of the files. This leads to a **concurrent modification exception** when you start a **static export**. The reason is in class `CmsFlexCache` when trying to add the files to the cache which are not yet cached.