### PR TITLE
Fix wrong reference to formatter jsp

### DIFF
--- a/src/org/opencms/ugc/ugc_config.xsd
+++ b/src/org/opencms/ugc/ugc_config.xsd
@@ -57,7 +57,7 @@
 				<tab element="MaxUploadSize" collapse="false" name="Security" />
 			</tabs>
             <formatters>
-               <formatter type="*" uri="/system/modules/org.opencms.ugc/formatters/usergenerated-default.jsp" />
+               <formatter type="*" uri="/system/modules/org.opencms.base/formatters/usergenerated-default.jsp" />
             </formatters>	
             <searchsettings containerPageOnly="true" />		
         </xsd:appinfo>        


### PR DESCRIPTION
I have fixed the reference to the formatter `usergenerated-default.jsp` because the module `org.opencms.ugc` does not exist any more.