### PR TITLE
Projects-App: extend error log (minor)

### DIFF
--- a/src/org/opencms/ui/apps/projects/CmsProjectsTable.java
+++ b/src/org/opencms/ui/apps/projects/CmsProjectsTable.java
@@ -529,7 +529,7 @@ public class CmsProjectsTable extends Table {
                         cms.readGroup(project.getManagerGroupId()).getSimpleName());
                     item.getItemProperty(PROP_USER).setValue(cms.readGroup(project.getGroupId()).getSimpleName());
                 } catch (CmsException e) {
-                    LOG.error("Error reading project properties for " + project + "." + e.getLocalizedMessage(), e);
+                    LOG.error("Error reading project properties for " + project + ". " + e.getLocalizedMessage(), e);
                 }
                 item.getItemProperty(PROP_DATE_CREATED).setValue(new Date(project.getDateCreated()));
 

--- a/src/org/opencms/ui/apps/projects/CmsProjectsTable.java
+++ b/src/org/opencms/ui/apps/projects/CmsProjectsTable.java
@@ -529,7 +529,7 @@ public class CmsProjectsTable extends Table {
                         cms.readGroup(project.getManagerGroupId()).getSimpleName());
                     item.getItemProperty(PROP_USER).setValue(cms.readGroup(project.getGroupId()).getSimpleName());
                 } catch (CmsException e) {
-                    LOG.error("Error reading project properties for " + project.getSimpleName());
+                    LOG.error("Error reading project properties for " + project + "." + e.getLocalizedMessage(), e);
                 }
                 item.getItemProperty(PROP_DATE_CREATED).setValue(new Date(project.getDateCreated()));
 


### PR DESCRIPTION
When opening the projects app, one of our servers was logging many humble errors like this:

> 02 Jun 2021 17:19:22,324 ERROR https-openssl-nio2-8443-exec-1 [apps.projects.CmsProjectsTable: 532] - Error reading project properties for Offline

Due to missing info (OU), we couldn't identify what projects they were, neither why they were broken.