### PR TITLE
Fix warning "The Logger ... was created ..."

### DIFF
--- a/src/org/opencms/ui/apps/logfile/CmsLogChannelTable.java
+++ b/src/org/opencms/ui/apps/logfile/CmsLogChannelTable.java
@@ -38,6 +38,7 @@ import org.opencms.ui.contextmenu.CmsContextMenu;
 import org.opencms.ui.contextmenu.CmsContextMenu.ContextMenuItem;
 import org.opencms.ui.contextmenu.CmsContextMenu.ContextMenuItemClickEvent;
 import org.opencms.ui.contextmenu.CmsContextMenu.ContextMenuItemClickListener;
+import org.opencms.util.CmsLog4jUtil;
 import org.opencms.util.CmsStringUtil;
 
 import java.util.ArrayList;
@@ -379,7 +380,7 @@ public class CmsLogChannelTable extends Table {
         Item item = m_container.addItem(logger);
         if (item != null) {
             item.getItemProperty(TableColumn.Channel).setValue(logger.getName());
-            Logger parent = logger.getParent();
+            Logger parent = CmsLog4jUtil.getParentLogger(logger);
             item.getItemProperty(TableColumn.ParentChannel).setValue(parent != null ? parent.getName() : "none");
             item.getItemProperty(TableColumn.File).setValue(m_app.getLogFile(logger));
             item.getItemProperty(TableColumn.Level).setValue(LoggerLevel.fromLogger(logger));

--- a/src/org/opencms/ui/apps/logfile/CmsLogFileApp.java
+++ b/src/org/opencms/ui/apps/logfile/CmsLogFileApp.java
@@ -458,7 +458,7 @@ public class CmsLogFileApp extends A_CmsWorkplaceApp implements I_CmsCRUDApp<Log
         //iterate all parent loggers until a logger with appender was found
         while (!logger.equals(LogManager.getRootLogger())) {
 
-            logger = logger.getParent();
+            logger = CmsLog4jUtil.getParentLogger(logger);
             // if no Appender found from logger, select the Appender from parent logger
             if (count == 0) {
                 for (Appender appender : logger.getAppenders().values()) {

--- a/src/org/opencms/util/CmsLog4jUtil.java
+++ b/src/org/opencms/util/CmsLog4jUtil.java
@@ -35,6 +35,7 @@ import java.util.TreeMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.LoggerConfig;
 
 /**
  * Utilities for dealing with log4j loggers.<p>
@@ -91,4 +92,23 @@ public final class CmsLog4jUtil {
 
     }
 
+    /**
+     * Returns the parent of this Logger. If it doesn't already exist return a new created Logger.<p>
+     *
+     * This is a version of {@link Logger#getParent()} method that skips the check of {@code MessageFactory} that the
+     * former performs, avoiding a warning if both currentLogger and parent logger doesn't share the same {@code
+     * MessageFactory}.
+     *
+     * @return The parent Logger.
+     */
+    public static Logger getParentLogger(Logger currentLogger) {
+        final LoggerConfig loggerConfig = currentLogger.get();
+        final LoggerConfig lc = loggerConfig.getName().equals(currentLogger.getName()) ? loggerConfig
+                .getParent() : loggerConfig;
+        if (lc == null) {
+            return null;
+        }
+        final String lcName = lc.getName();
+        return (Logger) LogManager.getLogger(lcName);
+    }
 }


### PR DESCRIPTION
Fix https://github.com/alkacon/opencms-core/issues/726. The LogFileApp uses `Logger.getParent()` to collect information of all loggers, but this method performs a validation that results in a warning than can be safely ignored.

 This commit uses an intern implementation of `getParent` that mimics that of `Logger.getParent` but without performing the unneeded check.