### PR TITLE
setup: fix paths of logging files

### DIFF
--- a/src-setup/org/opencms/setup/CmsSetupBean.java
+++ b/src-setup/org/opencms/setup/CmsSetupBean.java
@@ -216,10 +216,7 @@ public class CmsSetupBean implements I_CmsShellCommands {
     protected List<String> m_installModules;
 
     /** Location for log file.  */
-    protected String m_logFile = CmsSystemInfo.FOLDER_WEBINF + CmsLog.FOLDER_LOGS + "setup.log";
-
-    /** Location for logs relative to the webapp folder.  */
-    protected String m_logsFolder = CmsSystemInfo.FOLDER_WEBINF + CmsLog.FOLDER_LOGS;
+    protected String m_logFile = OpenCms.getSystemInfo().getLogFileRfsFolder() + "setup.log";
 
     /** A map with lists of dependent module package names keyed by module package names. */
     protected Map<String, List<String>> m_moduleDependencies;
@@ -959,7 +956,7 @@ public class CmsSetupBean implements I_CmsShellCommands {
      */
     public String getLogName() {
 
-        return new StringBuffer(m_webAppRfsPath).append(m_logFile).toString();
+        return m_logFile;
     }
 
     /**

--- a/src-setup/org/opencms/setup/CmsUpdateBean.java
+++ b/src-setup/org/opencms/setup/CmsUpdateBean.java
@@ -238,7 +238,7 @@ public class CmsUpdateBean extends CmsSetupBean {
         super();
         m_preserveLibModules = Collections.emptyList();
         m_modulesFolder = FOLDER_UPDATE + CmsSystemInfo.FOLDER_MODULES;
-        m_logFile = CmsSystemInfo.FOLDER_WEBINF + CmsLog.FOLDER_LOGS + "update.log";
+        m_logFile = OpenCms.getSystemInfo().getLogFileRfsFolder() + "update.log";
     }
 
     /**

--- a/src/org/opencms/main/CmsLog.java
+++ b/src/org/opencms/main/CmsLog.java
@@ -251,4 +251,19 @@ public final class CmsLog {
 
         return m_logFileRfsPath;
     }
+
+    /**
+     * Returns the absolute path to the folder of the main OpenCms log file
+     * (in the "real" file system).<p>
+     *
+     * If the method returns <code>null</code>, this means that the log
+     * file is not managed by OpenCms.<p>
+     *
+     * @return the absolute path to the folder of the main OpenCms log file (in
+     * the "real" file system)
+     */
+    protected static String getLogFileRfsFolder() {
+
+        return m_logFileRfsFolder;
+    }
 }

--- a/src/org/opencms/main/CmsSystemInfo.java
+++ b/src/org/opencms/main/CmsSystemInfo.java
@@ -462,6 +462,21 @@ public class CmsSystemInfo {
     }
 
     /**
+     * Returns the absolute path to the folder of the main OpenCms log file
+     * (in the "real" file system).<p>
+     *
+     * If the method returns <code>null</code>, this means that the log
+     * file is not managed by OpenCms.<p>
+     *
+     * @return the absolute path to the folder of the main OpenCms log file (in
+     * the "real" file system)
+     */
+    public String getLogFileRfsFolder() {
+
+        return CmsLog.getLogFileRfsFolder();
+    }
+
+    /**
      * Returns the settings for the internal OpenCms email service.<p>
      *
      * @return the settings for the internal OpenCms email service

--- a/src/org/opencms/ui/apps/logfile/CmsLogFileApp.java
+++ b/src/org/opencms/ui/apps/logfile/CmsLogFileApp.java
@@ -87,16 +87,14 @@ import com.vaadin.ui.Window.CloseListener;
 import com.vaadin.ui.themes.ValoTheme;
 
 /**
- * Main class of Log managment app.<p>
+ * Main class of Log management app.<p>
  */
 public class CmsLogFileApp extends A_CmsWorkplaceApp implements I_CmsCRUDApp<Logger> {
 
     /**Log folder path.*/
-    protected static final String LOG_FOLDER = OpenCms.getSystemInfo().getLogFileRfsPath() == null
-    ? ""
-    : OpenCms.getSystemInfo().getLogFileRfsPath().substring(
-        0,
-        OpenCms.getSystemInfo().getLogFileRfsPath().lastIndexOf(File.separatorChar) + 1);
+    protected static final String LOG_FOLDER =
+            OpenCms.getSystemInfo().getLogFileRfsFolder() == null ?
+                    "" : OpenCms.getSystemInfo().getLogFileRfsFolder();
 
     /**Path to channel settings view.*/
     protected static String PATH_LOGCHANNEL = "log-channel";


### PR DESCRIPTION
The setup tool writes `setup.log` and `update.log` under the WEB-INF/log folder, disregarding opencms logging configuration (`opencms.logfile` and `opencms.logfolder`). If the folder doesn't exist, it doesn't create it and only prints a stacktrace, ignoring further logging.