### PR TITLE
Add and fix CmsContentService tests to the AllTests suite

### DIFF
--- a/test/data/imports/simpletest/manifest.xml
+++ b/test/data/imports/simpletest/manifest.xml
@@ -2570,5 +2570,25 @@
 			<relations/>
 			<accesscontrol/>
 		</file>
+		<file>
+			<destination>system/config</destination>
+			<type>folder</type>
+			<properties />
+		</file>
+		<file>
+			<destination>system/config/wysiwyg</destination>
+			<type>folder</type>
+			<uuidstructure>7289c0e4-d14c-11e8-9434-b90516ef3600</uuidstructure>
+			<datecreated>Mon, 27 Jun 2005 08:00:00 GMT</datecreated>
+			<flags>0</flags>
+			<properties>
+				<property>
+					<name>Title</name>
+					<value><![CDATA[Editor display options]]></value>
+				</property>
+			</properties>
+			<relations />
+			<accesscontrol />
+		</file>
 	</files>
 </export>

--- a/test/org/opencms/test/AllTests.java
+++ b/test/org/opencms/test/AllTests.java
@@ -86,6 +86,7 @@ public final class AllTests {
         suite.addTest(org.opencms.setup.AllTests.suite());
         suite.addTest(org.opencms.ade.configuration.AllTests.suite());
         suite.addTest(org.opencms.ade.containerpage.inherited.AllTests.suite());
+        suite.addTest(org.opencms.ade.contenteditor.AllTests.suite());
         suite.addTest(org.opencms.ade.sitemap.AllTests.suite());
         suite.addTest(org.opencms.cache.AllTests.suite());
         suite.addTest(org.opencms.configuration.AllTests.suite());


### PR DESCRIPTION
This commit adds the unit tests `TestCmsContentService.testRead*` to the `org.opencms.test.AllTests` suite (they were never added) and fixes them by creating the vfs-folder `/system/config/wysiwyg` that is required by the ade content editor during initialization.