### PR TITLE
add tinymce option 'link_default_protocol'

### DIFF
--- a/src-gwt/org/opencms/gwt/client/ui/input/tinymce/CmsTinyMCEHelper.java
+++ b/src-gwt/org/opencms/gwt/client/ui/input/tinymce/CmsTinyMCEHelper.java
@@ -151,7 +151,9 @@ public final class CmsTinyMCEHelper {
 				options.valid_elements = "*[*]";
 				options.allow_script_urls = true;
 			}
-
+			if (config.link_default_protocol) {
+				options.link_default_protocol = config.link_default_protocol;
+			}
 			if (config.toolbar_items) {
 				toolbarGroup = @org.opencms.gwt.client.ui.input.tinymce.CmsTinyMCEHelper::createToolbar(Lcom/google/gwt/core/client/JavaScriptObject;)(config.toolbar_items);
 				toolbarGroup += " | spellchecker";

--- a/src/org/opencms/widgets/CmsHtmlWidget.java
+++ b/src/org/opencms/widgets/CmsHtmlWidget.java
@@ -210,6 +210,10 @@ public class CmsHtmlWidget extends A_CmsHtmlWidget implements I_CmsADEWidget {
 
                 result.put("spellcheck_language", contentLocale.getLanguage());
             }
+            String linkDefaultProtocol = widgetOptions.getLinkDefaultProtocol();
+            if (CmsStringUtil.isNotEmptyOrWhitespaceOnly(linkDefaultProtocol)) {
+                result.put("link_default_protocol", linkDefaultProtocol);
+            }
         } catch (JSONException e) {
             LOG.error(e.getLocalizedMessage(), e);
         }

--- a/src/org/opencms/widgets/CmsHtmlWidgetOption.java
+++ b/src/org/opencms/widgets/CmsHtmlWidgetOption.java
@@ -296,6 +296,9 @@ public class CmsHtmlWidgetOption {
     /** Option for the "show/hide visual control characters" button. */
     public static final String OPTION_VISUALCHARS = "visualchars";
 
+    /** Option for the default protocol for links */
+    public static final String OPTION_LINKDEFAULTPROTOCOL = "linkdefaultprotocol:";
+
     /** The optional buttons that can be additionally added to the button bar. */
     public static final String[] OPTIONAL_BUTTONS = {
         OPTION_ANCHOR,
@@ -405,6 +408,9 @@ public class CmsHtmlWidgetOption {
     /** The style XML path. */
     private String m_stylesXmlPath;
 
+    /** The link default protocol */
+    private String m_linkDefaultProtocol;
+
     /**
      * Creates a new empty HTML widget object object.<p>
      */
@@ -502,6 +508,10 @@ public class CmsHtmlWidgetOption {
             result.append(OPTION_FORMATSELECT_OPTIONS);
             result.append(option.getFormatSelectOptions());
             added = true;
+        }
+        if (CmsStringUtil.isNotEmpty(option.getLinkDefaultProtocol())) {
+            result.append(OPTION_LINKDEFAULTPROTOCOL);
+            result.append(option.getLinkDefaultProtocol());
         }
 
         return result.toString();
@@ -862,6 +872,15 @@ public class CmsHtmlWidgetOption {
     }
 
     /**
+     * Returns the link default protocol to use when inserting/editing links via the link dialog.
+     * 
+     * @return the link default protocol to use when inserting/editing links via the link dialog
+     */
+    public String getLinkDefaultProtocol() {
+        return m_linkDefaultProtocol;
+    }
+
+    /**
      * Initializes the widget options from the given configuration String.<p>
      *
      * @param configuration the configuration String
@@ -1041,6 +1060,17 @@ public class CmsHtmlWidgetOption {
     public void setStylesXmlPath(String stylesXmlPath) {
 
         m_stylesXmlPath = stylesXmlPath;
+    }
+
+    /**
+     * Set the link default protocol to use when inserting/editing links via the link dialog
+     * 
+     * @param linkDefaultProtocol
+     *            the link default protocol to use when inserting/editing links via the link dialog
+     */
+    public void setLinkDefaultProtocol(String linkDefaultProtocol) {
+
+        m_linkDefaultProtocol = linkDefaultProtocol;
     }
 
     /**
@@ -1228,6 +1258,12 @@ public class CmsHtmlWidgetOption {
                     m_importCss = true;
                 } else if (option.startsWith(OPTION_ALLOWSCRIPTS)) {
                     m_allowScripts = true;
+                } else if (option.startsWith(OPTION_LINKDEFAULTPROTOCOL)) {
+                    // the link default protocol
+                    option = option.substring(OPTION_LINKDEFAULTPROTOCOL.length());
+                    if (CmsStringUtil.isNotEmptyOrWhitespaceOnly(option)) {
+                        setLinkDefaultProtocol(option);
+                    }
                 } else {
                     // check if option describes an additional button
                     if (OPTIONAL_BUTTONS_LIST.contains(option)) {


### PR DESCRIPTION
Add tinymce option 'link_default_protocol'.
https://www.tiny.cloud/docs/plugins/opensource/link/#link_default_protocol

The option can be set in opencms-vfs.xml in widget configuration for CmsHtmlWidget e.g. linkdefaultprotocol:https
 