### PR TITLE
build: delete obsolete dependency

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,7 +5,6 @@ dependencies {
     setupCompile sourceSets.main.output
     gwtCompile sourceSets.main.output
     gwtCompile sourceSets.modules.output
-    testCompile fileTree('webapp/setup/database'){ include '**/*.jar' }
     testCompile sourceSets.setup.output
     testCompile sourceSets.modules.output
     testCompile sourceSets.gwt.output

--- a/test/org/opencms/configuration/TestConfiguration.java
+++ b/test/org/opencms/configuration/TestConfiguration.java
@@ -69,11 +69,11 @@ public class TestConfiguration extends OpenCmsTestCase {
     public void testLoadXmlConfiguration() throws Exception {
 
         // get the file name of the input resource
-        String inputFile = CmsResource.getParentFolder(
+        String configurationDirName = CmsResource.getParentFolder(
             OpenCmsTestProperties.getResourcePathFromClassloader("org/opencms/configuration/opencms.xml"));
 
         // generate the configuration manager
-        CmsConfigurationManager manager = new CmsConfigurationManager(inputFile);
+        CmsConfigurationManager manager = new CmsConfigurationManager(configurationDirName);
 
         // now digest the XML
         manager.loadXmlConfiguration();
@@ -89,7 +89,7 @@ public class TestConfiguration extends OpenCmsTestCase {
         Iterator<I_CmsXmlConfiguration> i = allConfigurations.iterator();
         while (i.hasNext()) {
             I_CmsXmlConfiguration config = i.next();
-            String xmlOrigFile = inputFile + config.getXmlFileName();
+            String xmlOrigFile = configurationDirName + config.getXmlFileName();
             System.out.println("\n\nConfiguration instance: " + config + ":\n");
 
             // generate XML document for the configuration


### PR DESCRIPTION
Files previously located in `webapp/setup/database/**` were moved to `webapp/WEB-INF/setupdata/database/**` in OpenCms 11.0. Given that we have currently OpenCms 16.0, we can safely conclude that this dependency is no longer necessary.