### PR TITLE
build(gradle): remove mavenLocal to avoid inconsistent resolution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,6 @@ if (hasExtModules) {
 }
 
 repositories {
-    mavenLocal()
     if (project.hasProperty('additional_repositories')){
         additional_repositories.split(';').each{ repo ->
             maven { url repo }


### PR DESCRIPTION
Fixes https://github.com/alkacon/opencms-core/issues/826

Gradle was resolving artifacts from the local Maven repository (~/.m2) before remote repositories, which caused missing or incomplete artifacts (e.g. missing `*-sources.jar`) to block dependency resolution during GWT compilation.

`mavenLocal` is unnecessary unless Maven-built artifacts are required.