### PR TITLE
Feat: Added .csv and .ai file type mappings to VFS resource types

### DIFF
--- a/webapp/WEB-INF/config/opencms-vfs.xml
+++ b/webapp/WEB-INF/config/opencms-vfs.xml
@@ -51,6 +51,7 @@
                         <mapping suffix=".otf" />
                         <mapping suffix=".ttc" />
                         <mapping suffix=".ttf" />
+                        <mapping suffix=".csv" />
                     </mappings>
                     <param name="gallery.type.names">downloadgallery</param>
                 </type>
@@ -88,6 +89,7 @@
                         <mapping suffix=".qt" />
                         <mapping suffix=".avi" />
                         <mapping suffix=".pkpass" />
+                        <mapping suffix=".ai" />
                     </mappings>
                     <param name="gallery.type.names">downloadgallery</param>
                 </type>


### PR DESCRIPTION
This pull request adds resource type mappings for **.csv** and **.ai** file extensions in _opencms-vfs.xml_.

**Changes made:**
- Added **.csv** extension mapping to `CmsResourceTypePlain` (id=1), consistent with its `text/csv` MIME type already defined in the mimetypes section.
- Added **.ai** extension mapping to `CmsResourceTypeBinary` (id=2), consistent with its `application/postscript` MIME type already defined in the mimetypes section.