### PR TITLE
Fixed missing HttpOnly in CmsFlexResponse addCookie method

### DIFF
--- a/src/org/opencms/flex/CmsFlexResponse.java
+++ b/src/org/opencms/flex/CmsFlexResponse.java
@@ -435,6 +435,11 @@ public class CmsFlexResponse extends HttpServletResponseWrapper {
             header.append("; Secure");
         }
 
+        // HttpOnly
+        if (cookie.isHttpOnly()) {
+            header.append("; HttpOnly");
+        }
+
         addHeader("Set-Cookie", header.toString());
     }
 


### PR DESCRIPTION
Hello,

When using `CmsJspBean` I noticed that `getResponse().addCookie() `didn't properly set HttpOnly flag to the headers.
`CmsFlexResponse::addCookie` override doesn't seem to handle HttpOnly.

This pull request adds the HttpOnly support to the response wrapper.

## Changes made

Adding this condition to addCookie method.

```java
// HttpOnly
if (cookie.isHttpOnly()) {
    header.append("; HttpOnly");
}
```


## Temporary workaround

Using an unwrap to get the original response class, and thus the original addCookie implementation

(this is really hacky, but works)

```java
private HttpServletResponse unwrap(HttpServletResponse response) {
    while (response instanceof HttpServletResponseWrapper) {
        response = (HttpServletResponse) ((HttpServletResponseWrapper) response).getResponse();
    }
    return response;
}

// addJwtCookies is a custom helper I created to add my cookies
public void addJwtCookies(HttpServletResponse response, String jwt) {
    if (response instanceof CmsFlexResponse) {
        // Currently, CmsFlexResponse overrides addCookies and is missing any handling of HttpOnly
        response = unwrap(response);
    }

    Cookie jwtCookie = generateJwtCookie(jwt);
    response.addCookie(jwtCookie);
}
```

## To go further

I was wondering, is this override still useful? Would it be safer/more future-proof to keep the base implementation?

Thanks in advance!