### PR TITLE
Fix NullPointerException in CmsADEConfigData.hasFormatters() for resource types without a schema

### DIFF
--- a/src/org/opencms/ade/configuration/CmsADEConfigData.java
+++ b/src/org/opencms/ade/configuration/CmsADEConfigData.java
@@ -1724,6 +1724,13 @@ public class CmsADEConfigData {
             CmsXmlContentDefinition def = CmsXmlContentDefinition.getContentDefinitionForType(
                 cms,
                 resType.getTypeName());
+            if (def == null) {
+                LOG.warn(
+                    "Type '"
+                        + resType.getTypeName()
+                        + "' has no schema configured, cannot check whether it has formatters.");
+                return false;
+            }
             CmsFormatterConfiguration schemaFormatters = def.getContentHandler().getFormatterConfiguration(cms, null);
             CmsFormatterConfiguration formatters = getFormatters(cms, resType, schemaFormatters);
             for (CmsContainer cont : containers) {


### PR DESCRIPTION
## Problem

When a resource type referenced by a sitemap configuration is defined without a `schema` configuration parameter, opening the container page editor logs this error on every add-dialog build:

```
ERROR ... CmsAddDialogTypeHelper: Cannot invoke
"org.opencms.xml.CmsXmlContentDefinition.getContentHandler()" because "def" is null
  at org.opencms.ade.configuration.CmsADEConfigData.hasFormatters(CmsADEConfigData.java)
  at org.opencms.ade.containerpage.CmsContainerpageService$2.checkEnabled(...)
```

`CmsXmlContentDefinition.getContentDefinitionForType()` intentionally returns `null` in that case, but `hasFormatters()` dereferences the result unconditionally. The resulting `NullPointerException` is swallowed per type by `CmsAddDialogTypeHelper`, which also means the formatter check is silently skipped for the affected type (it shows up in the add menu even without any matching formatter).

## Fix

Treat a missing content definition as "no formatters" (`return false`) and log a warning that names the offending type, so the underlying misconfiguration is diagnosable from the log instead of surfacing as an NPE.

The sibling method `getTypesWithModifiableFormatters()` in the same class already handles the `null` return from `getContentDefinitionForType()` this way.

## Verification

- `./gradlew compileJava` passes.
- Reproduced and verified against a 21.0-based installation where a type without a schema param was referenced by a sitemap configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)