### PR TITLE
Fix silently swallowed Solr core initialization failures

### DIFF
--- a/src/org/opencms/search/CmsSearchManager.java
+++ b/src/org/opencms/search/CmsSearchManager.java
@@ -2281,7 +2281,12 @@ public class CmsSearchManager implements I_CmsScheduledJob, I_CmsEventListener {
                 properties.put(CoreDescriptor.CORE_DATADIR, dataDir.getAbsolutePath());
                 properties.put(CoreDescriptor.CORE_CONFIGSET, "default");
                 core = m_coreContainer.create(index.getCoreName(), instanceDir.toPath(), properties, false);
-            } catch (NullPointerException e) {
+            } catch (RuntimeException e) {
+                // catch not only NPE, but also e.g. SolrException when the core cannot be created
+                // (like IndexFormatTooOldException for an index written by an older Lucene version):
+                // otherwise the exception propagates past the CmsConfigurationException handling in
+                // CmsSolrIndex#initialize(), the index stays enabled without a Solr client and every
+                // query later fails with a NullPointerException on the missing client
                 if (core != null) {
                     core.close();
                 }
@@ -3146,6 +3151,10 @@ public class CmsSearchManager implements I_CmsScheduledJob, I_CmsEventListener {
                 try {
                     index.initialize();
                 } catch (Exception e) {
+                    // disable the index - without this, an initialization failure that is not
+                    // handled inside initialize() itself leaves the index enabled and the
+                    // status report below wrongly logs it as successfully configured
+                    index.setEnabled(false);
                     if (CmsLog.INIT.isWarnEnabled()) {
                         // in this case the index will be disabled
                         CmsLog.INIT.warn(Messages.get().getBundle().key(Messages.INIT_SEARCH_INIT_FAILED_1, index), e);


### PR DESCRIPTION
## Problem

When the embedded Solr core of a `CmsSolrIndex` cannot be created, the failure is effectively swallowed and the index is left in a broken-but-enabled state:

1. In `CmsSearchManager#registerSolrIndex()`, only `NullPointerException` is caught around `CoreContainer.create(...)`. Any other `RuntimeException` — e.g. a `SolrException` wrapping an `org.apache.lucene.index.IndexFormatTooOldException` — propagates raw.
2. It therefore bypasses the `CmsConfigurationException` handling in `CmsSolrIndex#initialize()` that would disable the index, and lands in the broad `catch (Exception)` of `CmsSearchManager#initSearchIndexes()`, which only logs a WARN.
3. Because `setEnabled(false)` never ran, the status report right below logs the index as *successfully configured* (directly after the WARN about its failed initialization), and every later query against the index fails with an unexplained `NullPointerException` on the missing Solr client (`m_solr` is null).

This is not a theoretical path: after upgrading an installation to Solr/Lucene 10, a "Solr Online" index whose data directory was originally created with Lucene 8.x fails core creation with `IndexFormatTooOldException` (Lucene only reads indexes created by the current and previous major version). The only diagnostics are one WARN at startup plus misleading "successfully configured" INFO, followed by NPEs at query time. A follow-on symptom of the half-failed creation is `SolrException: Could not create a new core in .../solr/<name> as another core is already defined there` on re-initialization.

## Changes

- `registerSolrIndex()`: catch `RuntimeException` instead of only `NullPointerException` around core creation and wrap it into the existing `CmsConfigurationException`, so the index is disabled through the normal path with a clear error message.
- `initSearchIndexes()`: additionally call `index.setEnabled(false)` in the `catch` block, so any initialization failure not handled inside `initialize()` itself is reported truthfully by the status log instead of as a success.

## Status

Draft until tested against a real installation (reproduction environment: OpenCms with embedded Solr 10 and a Lucene-8-created index directory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
