### PR TITLE
Fix CSV user import with UTF-8 BOM and improve error handling

### DIFF
--- a/src/org/opencms/ui/apps/Messages.java
+++ b/src/org/opencms/ui/apps/Messages.java
@@ -3891,10 +3891,40 @@ public final class Messages extends A_CmsMessageBundle {
     public static final String RPT_USERIMPORT_FILE_CONTAINS_1 = "RPT_USERIMPORT_FILE_CONTAINS_1";
 
     /** Message constant for key in the resource bundle. */
+    public static final String RPT_USERIMPORT_GROUP_FAILED_2 = "RPT_USERIMPORT_GROUP_FAILED_2";
+
+    /** Message constant for key in the resource bundle. */
+    public static final String RPT_USERIMPORT_IMPORT_EMPTY_NAME_0 = "RPT_USERIMPORT_IMPORT_EMPTY_NAME_0";
+
+    /** Message constant for key in the resource bundle. */
+    public static final String RPT_USERIMPORT_IMPORT_EMPTY_RECORD_0 = "RPT_USERIMPORT_IMPORT_EMPTY_RECORD_0";
+
+    /** Message constant for key in the resource bundle. */
+    public static final String RPT_USERIMPORT_IMPORT_FAILED_1 = "RPT_USERIMPORT_IMPORT_FAILED_1";
+
+    /** Message constant for key in the resource bundle. */
     public static final String RPT_USERIMPORT_IMPORT_ALREADY_IN_OU_1 = "RPT_USERIMPORT_IMPORT_ALREADY_IN_OU_1";
 
     /** Message constant for key in the resource bundle. */
+    public static final String RPT_USERIMPORT_IMPORT_CREATE_FAILED_1 = "RPT_USERIMPORT_IMPORT_CREATE_FAILED_1";
+
+    /** Message constant for key in the resource bundle. */
     public static final String RPT_USERIMPORT_IMPORT_SUCCESFULL_1 = "RPT_USERIMPORT_IMPORT_SUCCESFULL_1";
+
+    /** Message constant for key in the resource bundle. */
+    public static final String RPT_USERIMPORT_MAIL_FAILED_1 = "RPT_USERIMPORT_MAIL_FAILED_1";
+
+    /** Message constant for key in the resource bundle. */
+    public static final String RPT_USERIMPORT_PASSWORD_EMPTY_1 = "RPT_USERIMPORT_PASSWORD_EMPTY_1";
+
+    /** Message constant for key in the resource bundle. */
+    public static final String RPT_USERIMPORT_PASSWORD_ENCRYPTION_FAILED_1 = "RPT_USERIMPORT_PASSWORD_ENCRYPTION_FAILED_1";
+
+    /** Message constant for key in the resource bundle. */
+    public static final String RPT_USERIMPORT_ROLE_FAILED_2 = "RPT_USERIMPORT_ROLE_FAILED_2";
+
+    /** Message constant for key in the resource bundle. */
+    public static final String RPT_USERIMPORT_SETTINGS_FAILED_1 = "RPT_USERIMPORT_SETTINGS_FAILED_1";
 
     /** Name of the used resource bundle. */
     private static final String BUNDLE_NAME = "org.opencms.ui.apps.messages";

--- a/src/org/opencms/ui/apps/messages.properties
+++ b/src/org/opencms/ui/apps/messages.properties
@@ -1376,6 +1376,16 @@ RPT_USERIMPORT_BEGIN_0=Userimport from csv-file starts..
 RPT_USERIMPORT_FILE_CONTAINS_1=The file contains {0} user.
 RPT_USERIMPORT_IMPORT_SUCCESFULL_1=User {0} was imported successfully
 RPT_USERIMPORT_IMPORT_ALREADY_IN_OU_1=A user with the name {0} is in the given OU. Ignore this user for import.
+RPT_USERIMPORT_IMPORT_FAILED_1=Unable to import user {0}. See the OpenCms log for details.
+RPT_USERIMPORT_IMPORT_EMPTY_RECORD_0=Unable to import an empty user record.
+RPT_USERIMPORT_IMPORT_EMPTY_NAME_0=Unable to import user: the user name is empty.
+RPT_USERIMPORT_IMPORT_CREATE_FAILED_1=Unable to create user {0}. See the OpenCms log for details.
+RPT_USERIMPORT_PASSWORD_EMPTY_1=Unable to import user {0}: password is empty.
+RPT_USERIMPORT_PASSWORD_ENCRYPTION_FAILED_1=Unable to import user {0}: password encryption failed.
+RPT_USERIMPORT_GROUP_FAILED_2=User {0} could not be added to group {1}.
+RPT_USERIMPORT_ROLE_FAILED_2=User {0} could not be added to role {1}.
+RPT_USERIMPORT_SETTINGS_FAILED_1=User {0} was created, but its workplace settings could not be saved.
+RPT_USERIMPORT_MAIL_FAILED_1=User {0} was created, but the notification email failed.
 RPT_USERIMPORT_END_0=Userimport has finished.
 
 GUI_RESOURCETYPE_NAME_0=Resource typ

--- a/src/org/opencms/ui/apps/user/CmsCsvImportUtils.java
+++ b/src/org/opencms/ui/apps/user/CmsCsvImportUtils.java
@@ -8,9 +8,41 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * For further information about Alkacon Software GmbH & Co. KG, please see the
+ * company website: https://www.alkacon.com
+ *
+ * For further information about OpenCms, please see the
+ * project website: https://www.opencms.org
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
 package org.opencms.ui.apps.user;
+
+import org.opencms.file.CmsUser;
+import org.opencms.main.CmsRuntimeException;
+import org.opencms.util.CmsStringUtil;
+import org.opencms.util.CmsXsltUtil;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.base.Splitter;
 
 /**
  * Utility methods for CSV user imports.<p>
@@ -45,5 +77,188 @@ final class CmsCsvImportUtils {
             result = result.substring(1, result.length() - 1);
         }
         return result;
+    }
+
+    /**
+     * Parses CSV user import data.<p>
+     *
+     * @param data the UTF-8 encoded CSV data
+     * @param defaultPassword the password to use if the CSV password should not be used
+     * @param keepPasswordIfPossible true if a CSV password value should be imported
+     *
+     * @return the parsed users
+     */
+    static List<CmsUser> readUsers(byte[] data, String defaultPassword, boolean keepPasswordIfPossible) {
+
+        List<CmsUser> users = new ArrayList<CmsUser>();
+        List<String> columns = null;
+        String separator = null;
+        int lineNumber = 0;
+
+        try (BufferedReader reader = new BufferedReader(
+            new InputStreamReader(new ByteArrayInputStream(data), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                lineNumber++;
+                if ((lineNumber == 1) && CmsStringUtil.isEmptyOrWhitespaceOnly(line)) {
+                    throw new IllegalArgumentException("The CSV header is empty.");
+                }
+                if (separator == null) {
+                    separator = CmsXsltUtil.getPreferredDelimiter(line);
+                    if (CmsStringUtil.isEmptyOrWhitespaceOnly(separator)) {
+                        throw new IllegalArgumentException("Unable to detect the CSV separator.");
+                    }
+                }
+                List<String> lineValues = Splitter.on(separator).splitToList(line);
+                if (columns == null) {
+                    columns = normalizeHeader(lineValues);
+                    validateHeader(columns);
+                    continue;
+                }
+                if (CmsStringUtil.isEmptyOrWhitespaceOnly(line)) {
+                    continue;
+                }
+                users.add(parseUser(columns, lineValues, lineNumber, defaultPassword, keepPasswordIfPossible));
+            }
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Unable to read the CSV user import file.", e);
+        }
+
+        if (columns == null) {
+            throw new IllegalArgumentException("The CSV file does not contain a header.");
+        }
+        return users;
+    }
+
+    /**
+     * Gets a normalized value by column name.<p>
+     *
+     * @param columns the normalized columns
+     * @param rawValues the raw values
+     * @param columnName the column name
+     *
+     * @return the value
+     */
+    private static String getValue(List<String> columns, List<String> rawValues, String columnName) {
+
+        int index = columns.indexOf(columnName);
+        String value = ((index >= 0) && (index < rawValues.size())) ? normalizeToken(rawValues.get(index)) : "";
+        return value == null ? "" : value;
+    }
+
+    /**
+     * Normalizes the CSV header.<p>
+     *
+     * @param rawHeader the raw header fields
+     *
+     * @return the normalized header fields
+     */
+    private static List<String> normalizeHeader(List<String> rawHeader) {
+
+        List<String> result = new ArrayList<String>();
+        for (int i = 0; i < rawHeader.size(); i++) {
+            String column = normalizeToken(rawHeader.get(i));
+            if (column != null) {
+                column = column.trim();
+            }
+            if (CmsStringUtil.isEmptyOrWhitespaceOnly(column)) {
+                throw new IllegalArgumentException("CSV column " + (i + 1) + " has an empty name.");
+            }
+            if (result.contains(column)) {
+                throw new IllegalArgumentException("Duplicate CSV column '" + column + "'.");
+            }
+            result.add(column);
+        }
+        return result;
+    }
+
+    /**
+     * Parses a single CSV user line.<p>
+     *
+     * @param columns the normalized columns
+     * @param rawValues the raw values
+     * @param lineNumber the CSV line number
+     * @param defaultPassword the default password
+     * @param keepPasswordIfPossible true if CSV passwords should be imported
+     *
+     * @return the parsed user
+     */
+    private static CmsUser parseUser(
+        List<String> columns,
+        List<String> rawValues,
+        int lineNumber,
+        String defaultPassword,
+        boolean keepPasswordIfPossible) {
+
+        CmsUser user = new CmsUser();
+        String userName = getValue(columns, rawValues, "name");
+        if (CmsStringUtil.isEmptyOrWhitespaceOnly(userName)) {
+            throw new IllegalArgumentException("CSV line " + lineNumber + " does not contain a user name.");
+        }
+        for (int i = 0; i < columns.size(); i++) {
+            String column = columns.get(i);
+            String value = i < rawValues.size() ? normalizeToken(rawValues.get(i)) : "";
+            if (value == null) {
+                value = "";
+            }
+            if ("password".equals(column)
+                && (CmsStringUtil.isEmptyOrWhitespaceOnly(value) || !keepPasswordIfPossible)) {
+                value = defaultPassword;
+            }
+            setUserValue(user, column, value, lineNumber);
+        }
+        if (CmsStringUtil.isEmptyOrWhitespaceOnly(user.getName())) {
+            throw new IllegalArgumentException("CSV line " + lineNumber + " does not contain a user name.");
+        }
+        if (CmsStringUtil.isEmptyOrWhitespaceOnly(user.getPassword())) {
+            user.setPassword(defaultPassword);
+        }
+        return user;
+    }
+
+    /**
+     * Sets a field value on a user by reflection or stores it as additional information.<p>
+     *
+     * @param user the user
+     * @param column the CSV column
+     * @param value the CSV value
+     * @param lineNumber the CSV line number
+     */
+    private static void setUserValue(CmsUser user, String column, String value, int lineNumber) {
+
+        if (CmsStringUtil.isEmptyOrWhitespaceOnly(value) || "null".equals(value)) {
+            return;
+        }
+        try {
+            Method method = CmsUser.class.getMethod(
+                "set" + column.substring(0, 1).toUpperCase() + column.substring(1),
+                new Class[] {String.class});
+            method.invoke(user, new Object[] {value});
+        } catch (NoSuchMethodException e) {
+            user.setAdditionalInfo(column, value);
+        } catch (IllegalAccessException e) {
+            throw new IllegalArgumentException(
+                "CSV line " + lineNumber + ": field '" + column + "' is not accessible.",
+                e);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause() == null ? e : e.getCause();
+            throw new IllegalArgumentException(
+                "CSV line " + lineNumber + ": invalid value for field '" + column + "'.",
+                cause);
+        } catch (CmsRuntimeException e) {
+            throw new IllegalArgumentException("CSV line " + lineNumber + ": unable to set field '" + column + "'.", e);
+        }
+    }
+
+    /**
+     * Validates the CSV header.<p>
+     *
+     * @param columns the normalized columns
+     */
+    private static void validateHeader(List<String> columns) {
+
+        if (!columns.contains("name")) {
+            throw new IllegalArgumentException("The mandatory CSV column 'name' is missing.");
+        }
     }
 }

--- a/src/org/opencms/ui/apps/user/CmsCsvImportUtils.java
+++ b/src/org/opencms/ui/apps/user/CmsCsvImportUtils.java
@@ -1,0 +1,49 @@
+/*
+ * This library is part of OpenCms -
+ * the Open Source Content Management System
+ *
+ * Copyright (c) Alkacon Software GmbH & Co. KG (https://www.alkacon.com)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ */
+
+package org.opencms.ui.apps.user;
+
+/**
+ * Utility methods for CSV user imports.<p>
+ */
+final class CmsCsvImportUtils {
+
+    /** UTF-8 byte order mark. */
+    private static final String BOM = "\ufeff";
+
+    /** Hidden constructor. */
+    private CmsCsvImportUtils() {
+
+        // utility class
+    }
+
+    /**
+     * Normalizes a CSV field name or value by removing an optional UTF-8 BOM and matching surrounding quotes.<p>
+     *
+     * @param value the raw CSV token
+     * @return the normalized token
+     */
+    static String normalizeToken(String value) {
+
+        if (value == null) {
+            return null;
+        }
+        String result = value;
+        if (result.startsWith(BOM)) {
+            result = result.substring(BOM.length());
+        }
+        if ((result.length() >= 2) && result.startsWith("\"") && result.endsWith("\"")) {
+            result = result.substring(1, result.length() - 1);
+        }
+        return result;
+    }
+}

--- a/src/org/opencms/ui/apps/user/CmsImportExportUserDialog.java
+++ b/src/org/opencms/ui/apps/user/CmsImportExportUserDialog.java
@@ -8,6 +8,21 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * For further information about Alkacon Software, please see the
+ * company website: https://www.alkacon.com
+ *
+ * For further information about OpenCms, please see the
+ * project website: https://www.opencms.org
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
 package org.opencms.ui.apps.user;
@@ -16,7 +31,6 @@ import org.opencms.file.CmsObject;
 import org.opencms.file.CmsUser;
 import org.opencms.main.CmsException;
 import org.opencms.main.CmsLog;
-import org.opencms.main.CmsRuntimeException;
 import org.opencms.main.OpenCms;
 import org.opencms.security.CmsRole;
 import org.opencms.security.I_CmsPrincipal;
@@ -31,16 +45,9 @@ import org.opencms.ui.dialogs.permissions.CmsPrincipalSelect;
 import org.opencms.ui.dialogs.permissions.CmsPrincipalSelect.WidgetType;
 import org.opencms.util.CmsStringUtil;
 import org.opencms.util.CmsUUID;
-import org.opencms.util.CmsXsltUtil;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -49,7 +56,6 @@ import java.util.Map;
 
 import org.apache.commons.logging.Log;
 
-import com.google.common.base.Splitter;
 import com.google.common.base.Supplier;
 import com.vaadin.data.HasValue.ValueChangeEvent;
 import com.vaadin.data.HasValue.ValueChangeListener;
@@ -342,128 +348,10 @@ implements Receiver, I_CmsPasswordFetcher {
             throw new IllegalArgumentException("No CSV import data is available.");
         }
 
-        boolean keepPasswordIfPossible = m_importPasswords.getValue().booleanValue();
-        List<CmsUser> users = new ArrayList<CmsUser>();
-        List<String> columns = null;
-        String separator = null;
-        int lineNumber = 0;
-
-        try (BufferedReader reader = new BufferedReader(
-            new InputStreamReader(new ByteArrayInputStream(m_importFileStream.toByteArray())))) {
-            String line;
-            while ((line = reader.readLine()) != null) {
-                lineNumber++;
-                if ((lineNumber == 1) && CmsStringUtil.isEmptyOrWhitespaceOnly(line)) {
-                    throw new IllegalArgumentException("The CSV header is empty.");
-                }
-                if (separator == null) {
-                    separator = CmsXsltUtil.getPreferredDelimiter(line);
-                }
-                List<String> lineValues = Splitter.on(separator).splitToList(line);
-                if (columns == null) {
-                    columns = normalizeHeader(lineValues);
-                    validateHeader(columns);
-                    continue;
-                }
-                if (CmsStringUtil.isEmptyOrWhitespaceOnly(line)) {
-                    continue;
-                }
-                users.add(parseUser(columns, lineValues, lineNumber, keepPasswordIfPossible));
-            }
-        } catch (IOException e) {
-            throw new CmsRuntimeException("Unable to read the CSV user import file.", e);
-        }
-
-        if (columns == null) {
-            throw new IllegalArgumentException("The CSV file does not contain a header.");
-        }
-        return users;
-    }
-
-    private List<String> normalizeHeader(List<String> rawHeader) {
-
-        List<String> result = new ArrayList<String>();
-        for (int i = 0; i < rawHeader.size(); i++) {
-            String column = CmsCsvImportUtils.normalizeToken(rawHeader.get(i));
-            if (column != null) {
-                column = column.trim();
-            }
-            if (CmsStringUtil.isEmptyOrWhitespaceOnly(column)) {
-                throw new IllegalArgumentException("CSV column " + (i + 1) + " has an empty name.");
-            }
-            if (result.contains(column)) {
-                throw new IllegalArgumentException("Duplicate CSV column '" + column + "'.");
-            }
-            result.add(column);
-        }
-        return result;
-    }
-
-    private CmsUser parseUser(
-        List<String> columns,
-        List<String> rawValues,
-        int lineNumber,
-        boolean keepPasswordIfPossible) {
-
-        CmsUser user = new CmsUser();
-        for (int i = 0; i < columns.size(); i++) {
-            String column = columns.get(i);
-            String value = i < rawValues.size() ? CmsCsvImportUtils.normalizeToken(rawValues.get(i)) : "";
-            if (value == null) {
-                value = "";
-            }
-            if ("password".equals(column)
-                && (CmsStringUtil.isEmptyOrWhitespaceOnly(value) || !keepPasswordIfPossible)) {
-                value = m_password.getValue();
-            }
-            setUserValue(user, column, value, lineNumber);
-        }
-        if (CmsStringUtil.isEmptyOrWhitespaceOnly(user.getName())) {
-            throw new IllegalArgumentException("CSV line " + lineNumber + " does not contain a user name.");
-        }
-        if (CmsStringUtil.isEmptyOrWhitespaceOnly(user.getPassword())) {
-            user.setPassword(m_password.getValue());
-        }
-        return user;
-    }
-
-    private void setUserValue(CmsUser user, String column, String value, int lineNumber) {
-
-        if (CmsStringUtil.isEmptyOrWhitespaceOnly(value) || "null".equals(value)) {
-            return;
-        }
-        try {
-            Method method = CmsUser.class.getMethod(
-                "set" + column.substring(0, 1).toUpperCase() + column.substring(1),
-                new Class[] {String.class});
-            method.invoke(user, new Object[] {value});
-        } catch (NoSuchMethodException e) {
-            user.setAdditionalInfo(column, value);
-        } catch (IllegalAccessException e) {
-            throw new IllegalArgumentException(
-                "CSV line " + lineNumber + ": field '" + column + "' is not accessible.",
-                e);
-        } catch (InvocationTargetException e) {
-            Throwable cause = e.getCause() == null ? e : e.getCause();
-            throw new IllegalArgumentException(
-                "CSV line " + lineNumber + ": invalid value for field '" + column + "'.",
-                cause);
-        } catch (CmsRuntimeException e) {
-            throw new IllegalArgumentException(
-                "CSV line " + lineNumber + ": unable to set field '" + column + "'.",
-                e);
-        }
-    }
-
-    private void validateHeader(List<String> columns) {
-
-        if (!columns.contains("name")) {
-            throw new IllegalArgumentException("The mandatory CSV column 'name' is missing.");
-        }
-        if (!columns.contains("password")) {
-            LOG.warn(
-                "CSV user import does not contain a password column. The password configured in the dialog will be used for all users.");
-        }
+        return CmsCsvImportUtils.readUsers(
+            m_importFileStream.toByteArray(),
+            m_password.getValue(),
+            m_importPasswords.getValue().booleanValue());
     }
 
     protected void importUserFromFile() {

--- a/src/org/opencms/ui/apps/user/CmsImportExportUserDialog.java
+++ b/src/org/opencms/ui/apps/user/CmsImportExportUserDialog.java
@@ -8,21 +8,6 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * Lesser General Public License for more details.
- *
- * For further information about Alkacon Software, please see the
- * company website: https://www.alkacon.com
- *
- * For further information about OpenCms, please see the
- * project website: https://www.opencms.org
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
 package org.opencms.ui.apps.user;
@@ -51,7 +36,6 @@ import org.opencms.util.CmsXsltUtil;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
@@ -84,107 +68,42 @@ import com.vaadin.ui.Upload.SucceededEvent;
 import com.vaadin.ui.VerticalLayout;
 import com.vaadin.ui.Window;
 
-/**
- * Dialog for CSV im- and export.<p>
- */
+/** Dialog for CSV user import and export. */
 public final class CmsImportExportUserDialog extends A_CmsImportExportUserDialog
 implements Receiver, I_CmsPasswordFetcher {
 
-    /** The "bom" bytes as String that need to be placed at the very beginning of the produced csv. */
-    private static final String BOM = "\ufeff";
-
-    /**The dialog height. */
     public static final String DIALOG_HEIGHT = "650px";
 
-    /** Log instance for this class. */
     static final Log LOG = CmsLog.getLog(CmsImportExportUserDialog.class);
 
-    /**vaadin serial id. */
     private static final long serialVersionUID = -2055302491540892101L;
 
-    /**Label to show uploaded file. */
     protected Label m_uploadname;
-
-    /**Start import button. */
     Button m_startImport;
-
-    /**Vaadin Component. */
     private Panel m_includeTechnicalFieldsPanel;
-
-    /**Vaadin Component. */
     private CheckBox m_includeTechnicalFields;
-
-    /**Cancel button. */
     private Button m_cancel;
-
-    /**CmsObject. */
     private CmsObject m_cms;
-
-    /**Download button for export. */
     private Button m_download;
-
-    /**Layout for groups. */
     private VerticalLayout m_exportGroups;
-
-    /**Groups. */
     private CmsEditableGroup m_exportGroupsGroup;
-
-    /**Layout for roles. */
     private VerticalLayout m_exportRoles;
-
-    /**Roles. */
     private CmsEditableGroup m_exportRolesGroup;
-
-    /**Generate password button. */
     private Button m_generateButton;
-
-    /**Should the group field be editable? */
     private boolean m_groupEditable = true;
-
-    /**ID of group. */
     private CmsUUID m_groupID;
-
-    /**Stream for upload file. */
     private ByteArrayOutputStream m_importFileStream;
-
-    /**Layout for groups.*/
     private VerticalLayout m_importGroups;
-
-    /**Groups. */
     private CmsEditableGroup m_importGroupsGroup;
-
-    /**Should password be imported? */
     private CheckBox m_importPasswords;
-
-    /**Layout for roles. */
     private VerticalLayout m_importRoles;
-
-    /**Roles. */
     private CmsEditableGroup m_importRolesGroup;
-
-    /**Password for imported user. */
     private TextField m_password;
-
-    /**List of user to import. */
     List<CmsUser> m_userImportList;
-
-    /**Should the user get an email? */
     private CheckBox m_sendMail;
-
-    /**Tab with import and export sheet. */
     private TabSheet m_tab;
-
-    /**Upload for import. */
     private Upload m_upload;
 
-    /**
-     * public constructor.<p>
-     *
-     * @param ou ou name
-     * @param groupID id of group
-     * @param window window
-     * @param allowTechnicalFieldsExport flag indicates if technical field export option should be available
-     */
     private CmsImportExportUserDialog(
         final String ou,
         CmsUUID groupID,
@@ -192,13 +111,11 @@ implements Receiver, I_CmsPasswordFetcher {
         boolean allowTechnicalFieldsExport) {
 
         setHeight(DIALOG_HEIGHT);
-
         m_groupID = groupID;
-
         try {
             m_cms = OpenCms.initCmsObject(A_CmsUI.getCmsObject());
-        } catch (CmsException e1) {
-            //
+        } catch (CmsException e) {
+            LOG.error("Unable to initialize the CMS context for CSV user import/export.", e);
         }
         CmsVaadinUtils.readAndLocalizeDesign(this, CmsVaadinUtils.getWpMessagesForCurrentLocale(), null);
         m_includeTechnicalFieldsPanel.setVisible(allowTechnicalFieldsExport);
@@ -207,22 +124,16 @@ implements Receiver, I_CmsPasswordFetcher {
             public void valueChange(ValueChangeEvent event) {
 
                 initDownloadButton();
-
             }
-
         });
         m_importPasswords.setValue(Boolean.TRUE);
         m_sendMail.setValue(Boolean.TRUE);
-
         setButtonVisibility(0);
-
         m_tab.addSelectedTabChangeListener(
             event -> setButtonVisibility(m_tab.getTabPosition(m_tab.getTab(m_tab.getSelectedTab()))));
-
         m_password.setValue(CmsGeneratePasswordDialog.getRandomPassword());
         m_startImport.setEnabled(false);
         m_startImport.addClickListener(event -> importUserFromFile());
-
         m_generateButton.addClickListener(new Button.ClickListener() {
 
             private static final long serialVersionUID = 4128513094772586752L;
@@ -239,16 +150,13 @@ implements Receiver, I_CmsPasswordFetcher {
                         public void run() {
 
                             windowDialog.close();
-
                         }
                     });
                 windowDialog.setContent(dialog);
                 A_CmsUI.get().addWindow(windowDialog);
             }
         });
-
         m_upload.setReceiver(this);
-
         m_upload.addSucceededListener(new Upload.SucceededListener() {
 
             private static final long serialVersionUID = -6865652127878123021L;
@@ -257,10 +165,10 @@ implements Receiver, I_CmsPasswordFetcher {
 
                 try {
                     m_userImportList = getUsersFromFile();
-                    m_startImport.setEnabled(true);
+                    m_startImport.setEnabled(!m_userImportList.isEmpty());
                     m_uploadname.setValue(event.getFilename());
-                } catch (Exception e) {
-                    //wrong csv columns
+                } catch (RuntimeException e) {
+                    LOG.error("Invalid CSV user import file '" + event.getFilename() + "'.", e);
                     m_startImport.setEnabled(false);
                     m_uploadname.setValue("");
                     CmsConfirmationDialog.show(
@@ -270,35 +178,29 @@ implements Receiver, I_CmsPasswordFetcher {
 
                             public void run() {
 
+                                // nothing to do
                             }
-
                         });
                 }
             }
         });
 
         if (groupID == null) {
-
             m_importGroupsGroup = new CmsEditableGroup(m_importGroups, new Supplier<Component>() {
 
                 public Component get() {
 
                     return getGroupSelect(ou, true, null);
                 }
-
             }, CmsVaadinUtils.getMessageText(Messages.GUI_USERMANAGEMENT_USER_IMEXPORT_ADD_GROUP_0));
-
             m_importGroupsGroup.init();
-
             m_exportGroupsGroup = new CmsEditableGroup(m_exportGroups, new Supplier<Component>() {
 
                 public Component get() {
 
                     return getGroupSelect(ou, true, null);
                 }
-
             }, CmsVaadinUtils.getMessageText(Messages.GUI_USERMANAGEMENT_USER_IMEXPORT_ADD_GROUP_0));
-
             m_exportGroupsGroup.init();
         } else {
             m_exportGroups.addComponent(getGroupSelect(ou, false, groupID));
@@ -311,42 +213,25 @@ implements Receiver, I_CmsPasswordFetcher {
 
                 return getRoleComboBox(ou);
             }
-
         }, CmsVaadinUtils.getMessageText(Messages.GUI_USERMANAGEMENT_USER_IMEXPORT_ADD_ROLE_0));
-
         m_importRolesGroup.init();
-
         m_exportRolesGroup = new CmsEditableGroup(m_exportRoles, new Supplier<Component>() {
 
             public Component get() {
 
                 return getRoleComboBox(ou);
             }
-
         }, CmsVaadinUtils.getMessageText(Messages.GUI_USERMANAGEMENT_USER_IMEXPORT_ADD_ROLE_0));
-
         m_exportRolesGroup.init();
-
         super.init(ou, window);
-
     }
 
-    /**
-     * Returns a map with the users to export added.<p>
-     * @param cms CmsObject
-     * @param ou ou name
-     * @param exportUsers the map to add the users
-     * @return a map with the users to export added
-     * @throws CmsException if getting users failed
-     */
     public static Map<CmsUUID, CmsUser> addExportAllUsers(CmsObject cms, String ou, Map<CmsUUID, CmsUser> exportUsers)
     throws CmsException {
 
         List<CmsUser> users = OpenCms.getOrgUnitManager().getUsers(cms, ou, false);
-        if ((users != null) && (users.size() > 0)) {
-            Iterator<CmsUser> itUsers = users.iterator();
-            while (itUsers.hasNext()) {
-                CmsUser user = itUsers.next();
+        if (users != null) {
+            for (CmsUser user : users) {
                 if (!exportUsers.containsKey(user.getId())) {
                     exportUsers.put(user.getId(), user);
                 }
@@ -355,31 +240,17 @@ implements Receiver, I_CmsPasswordFetcher {
         return exportUsers;
     }
 
-    /**
-     * Returns a map with the users to export added.<p>
-     * @param cms CmsObject
-     * @param groups the selected groups
-     * @param exportUsers the map to add the users
-     *
-     * @return a map with the users to export added
-     *
-     * @throws CmsException if getting groups or users of group failed
-     */
     public static Map<CmsUUID, CmsUser> addExportUsersFromGroups(
         CmsObject cms,
         List<String> groups,
         Map<CmsUUID, CmsUser> exportUsers)
     throws CmsException {
 
-        if ((groups != null) && (groups.size() > 0)) {
-            Iterator<String> itGroups = groups.iterator();
-            while (itGroups.hasNext()) {
-                List<CmsUser> groupUsers = cms.getUsersOfGroup(itGroups.next());
-                Iterator<CmsUser> itGroupUsers = groupUsers.iterator();
-                while (itGroupUsers.hasNext()) {
-                    CmsUser groupUser = itGroupUsers.next();
-                    if (!exportUsers.containsKey(groupUser.getId())) {
-                        exportUsers.put(groupUser.getId(), groupUser);
+        if (groups != null) {
+            for (String group : groups) {
+                for (CmsUser user : cms.getUsersOfGroup(group)) {
+                    if (!exportUsers.containsKey(user.getId())) {
+                        exportUsers.put(user.getId(), user);
                     }
                 }
             }
@@ -387,18 +258,6 @@ implements Receiver, I_CmsPasswordFetcher {
         return exportUsers;
     }
 
-    /**
-     * Returns a map with the users to export added.<p>
-     * @param cms CmsObject
-     * @param ou ou name
-     *
-     * @param roles the selected roles
-     * @param exportUsers the map to add the users
-     *
-     * @return a map with the users to export added
-     *
-     * @throws CmsException if getting roles or users of role failed
-     */
     public static Map<CmsUUID, CmsUser> addExportUsersFromRoles(
         CmsObject cms,
         String ou,
@@ -406,20 +265,16 @@ implements Receiver, I_CmsPasswordFetcher {
         Map<CmsUUID, CmsUser> exportUsers)
     throws CmsException {
 
-        if ((roles != null) && (roles.size() > 0)) {
-            Iterator<String> itRoles = roles.iterator();
-            while (itRoles.hasNext()) {
+        if (roles != null) {
+            for (String role : roles) {
                 List<CmsUser> roleUsers = OpenCms.getRoleManager().getUsersOfRole(
                     cms,
-                    CmsRole.valueOfGroupName(itRoles.next()).forOrgUnit(ou),
+                    CmsRole.valueOfGroupName(role).forOrgUnit(ou),
                     true,
                     false);
-                Iterator<CmsUser> itRoleUsers = roleUsers.iterator();
-                while (itRoleUsers.hasNext()) {
-                    CmsUser roleUser = itRoleUsers.next();
-                    // contains
-                    if (exportUsers.get(roleUser.getId()) == null) {
-                        exportUsers.put(roleUser.getId(), roleUser);
+                for (CmsUser user : roleUsers) {
+                    if (!exportUsers.containsKey(user.getId())) {
+                        exportUsers.put(user.getId(), user);
                     }
                 }
             }
@@ -427,68 +282,34 @@ implements Receiver, I_CmsPasswordFetcher {
         return exportUsers;
     }
 
-    /**
-     * Gets an dialog instance for fixed group.<p>
-     *
-     * @param groupID id
-     * @param ou ou name
-     * @param window window
-     * @param allowTechnicalFieldsExport flag indicates if technical field export option should be available
-     * @return an instance of this class
-         */
     public static CmsImportExportUserDialog getExportUserDialogForGroup(
         CmsUUID groupID,
         String ou,
         Window window,
         boolean allowTechnicalFieldsExport) {
 
-        CmsImportExportUserDialog res = new CmsImportExportUserDialog(ou, groupID, window, allowTechnicalFieldsExport);
-        return res;
+        return new CmsImportExportUserDialog(ou, groupID, window, allowTechnicalFieldsExport);
     }
 
-    /**
-     * Gets an dialog instance for fixed group.<p>
-     *
-     * @param ou ou name
-     * @param window window
-     * @param allowTechnicalFieldsExport flag indicates if technical field export option should be available
-     * @return an instance of this class
-     */
     public static CmsImportExportUserDialog getExportUserDialogForOU(
         String ou,
         Window window,
         boolean allowTechnicalFieldsExport) {
 
-        CmsImportExportUserDialog res = new CmsImportExportUserDialog(ou, null, window, allowTechnicalFieldsExport);
-        return res;
+        return new CmsImportExportUserDialog(ou, null, window, allowTechnicalFieldsExport);
     }
 
-    /**
-     * @see org.opencms.ui.apps.user.I_CmsPasswordFetcher#fetchPassword(java.lang.String)
-     */
     public void fetchPassword(String password) {
 
         m_password.setValue(password);
-
     }
 
-    /**
-     * @see com.vaadin.ui.Upload.Receiver#receiveUpload(java.lang.String, java.lang.String)
-     */
     public OutputStream receiveUpload(String filename, String mimeType) {
 
         m_importFileStream = new ByteArrayOutputStream();
         return m_importFileStream;
     }
 
-    /**
-     * Get a principle select for choosing groups.<p>
-     *
-     * @param ou name
-     * @param enabled enabled?
-     * @param groupID default value
-     * @return CmsPrinicpalSelect
-     */
     protected CmsPrincipalSelect getGroupSelect(String ou, boolean enabled, CmsUUID groupID) {
 
         CmsPrincipalSelect select = new CmsPrincipalSelect();
@@ -497,7 +318,6 @@ implements Receiver, I_CmsPasswordFetcher {
         select.setRealPrincipalsOnly(true);
         select.setPrincipalType(I_CmsPrincipal.PRINCIPAL_GROUP);
         select.setWidgetType(WidgetType.groupwidget);
-
         if (groupID != null) {
             try {
                 select.setValue(m_cms.readGroup(groupID).getName());
@@ -505,125 +325,147 @@ implements Receiver, I_CmsPasswordFetcher {
                 LOG.error("Unable to read group", e);
             }
         }
-
-        //OU Change enabled because ou-user can be part of other ou-groups
         return select;
     }
 
-    /**
-     * Get ComboBox for selecting roles.<p>
-     *
-     * @param ou name
-     * @return ComboBox
-     */
     protected ComboBox<CmsRole> getRoleComboBox(String ou) {
 
         ComboBox<CmsRole> box = new ComboBox<CmsRole>();
         CmsUserEditDialog.iniRole(A_CmsUI.getCmsObject(), ou, box, null);
         box.setSelectedItem(CmsRole.EDITOR.forOrgUnit(ou));
-
         return box;
     }
 
-    /**
-     * Reads user from import file.<p>
-     *
-     * @return List of user (with passwords)
-     */
     protected List<CmsUser> getUsersFromFile() {
 
-        String separator = null;
-        List values = null;
-
-        FileReader fileReader;
-        BufferedReader bufferedReader;
-        List<CmsUser> users = null;
+        if (m_importFileStream == null) {
+            throw new IllegalArgumentException("No CSV import data is available.");
+        }
 
         boolean keepPasswordIfPossible = m_importPasswords.getValue().booleanValue();
+        List<CmsUser> users = new ArrayList<CmsUser>();
+        List<String> columns = null;
+        String separator = null;
+        int lineNumber = 0;
 
-        try {
-            bufferedReader = new BufferedReader(
-                new InputStreamReader(new ByteArrayInputStream(m_importFileStream.toByteArray())));
+        try (BufferedReader reader = new BufferedReader(
+            new InputStreamReader(new ByteArrayInputStream(m_importFileStream.toByteArray())))) {
             String line;
-            boolean headline = true;
-            boolean hasBOM = false;
-            while ((line = bufferedReader.readLine()) != null) {
-                if (users == null) {
-                    users = new ArrayList<CmsUser>();
+            while ((line = reader.readLine()) != null) {
+                lineNumber++;
+                if ((lineNumber == 1) && CmsStringUtil.isEmptyOrWhitespaceOnly(line)) {
+                    throw new IllegalArgumentException("The CSV header is empty.");
                 }
                 if (separator == null) {
                     separator = CmsXsltUtil.getPreferredDelimiter(line);
                 }
-                List lineValues = Splitter.on(separator).splitToList(line);
-                if (headline) {
-                    values = new ArrayList();
-                    Iterator itLineValues = lineValues.iterator();
-                    while (itLineValues.hasNext()) {
-                        String va = (String)itLineValues.next();
-                        if (va.startsWith(BOM) && va.substring(1, 2).equals("\"")) {
-                            hasBOM = true;
-                            va = va.substring(1); //Cut BOM
-                        }
-                        if (hasBOM) {
-                            va = va.substring(1, va.length() - 1);
-                        }
-                        //}
-                        values.add(va);
-                    }
-                    headline = false;
-                } else if (values != null) {
-                    CmsUser curUser = new CmsUser();
-                    try {
-                        for (int i = 0; i < values.size(); i++) {
-                            String curValue = (String)values.get(i);
-                            try {
-                                Method method = CmsUser.class.getMethod(
-                                    "set" + curValue.substring(0, 1).toUpperCase() + curValue.substring(1),
-                                    new Class[] {String.class});
-                                String value = "";
-                                if ((lineValues.size() > i) && (lineValues.get(i) != null)) {
-                                    value = (String)lineValues.get(i);
-                                    if (hasBOM) {
-
-                                        value = value.substring(1, value.length() - 1);
-                                    }
-
-                                }
-                                if (curValue.equals("password")) {
-                                    if (CmsStringUtil.isEmptyOrWhitespaceOnly(value) | !keepPasswordIfPossible) {
-                                        value = m_password.getValue();
-                                    }
-                                }
-                                if (CmsStringUtil.isNotEmptyOrWhitespaceOnly(value) && !value.equals("null")) {
-                                    method.invoke(curUser, new Object[] {value});
-                                }
-                            } catch (NoSuchMethodException ne) {
-                                if (!CmsStringUtil.isEmptyOrWhitespaceOnly((String)lineValues.get(i))) {
-                                    curUser.setAdditionalInfo(curValue, lineValues.get(i));
-                                }
-                            } catch (IllegalAccessException le) {
-                                //
-                            } catch (InvocationTargetException te) {
-                                //
-                            }
-                        }
-                    } catch (CmsRuntimeException e) {
-                        //
-                    }
-                    users.add(curUser);
+                List<String> lineValues = Splitter.on(separator).splitToList(line);
+                if (columns == null) {
+                    columns = normalizeHeader(lineValues);
+                    validateHeader(columns);
+                    continue;
                 }
+                if (CmsStringUtil.isEmptyOrWhitespaceOnly(line)) {
+                    continue;
+                }
+                users.add(parseUser(columns, lineValues, lineNumber, keepPasswordIfPossible));
             }
-            bufferedReader.close();
         } catch (IOException e) {
-            //noop
+            throw new CmsRuntimeException("Unable to read the CSV user import file.", e);
         }
 
+        if (columns == null) {
+            throw new IllegalArgumentException("The CSV file does not contain a header.");
+        }
         return users;
     }
 
-    /**
-     * Import user from file.
-     */
+    private List<String> normalizeHeader(List<String> rawHeader) {
+
+        List<String> result = new ArrayList<String>();
+        for (int i = 0; i < rawHeader.size(); i++) {
+            String column = CmsCsvImportUtils.normalizeToken(rawHeader.get(i));
+            if (column != null) {
+                column = column.trim();
+            }
+            if (CmsStringUtil.isEmptyOrWhitespaceOnly(column)) {
+                throw new IllegalArgumentException("CSV column " + (i + 1) + " has an empty name.");
+            }
+            if (result.contains(column)) {
+                throw new IllegalArgumentException("Duplicate CSV column '" + column + "'.");
+            }
+            result.add(column);
+        }
+        return result;
+    }
+
+    private CmsUser parseUser(
+        List<String> columns,
+        List<String> rawValues,
+        int lineNumber,
+        boolean keepPasswordIfPossible) {
+
+        CmsUser user = new CmsUser();
+        for (int i = 0; i < columns.size(); i++) {
+            String column = columns.get(i);
+            String value = i < rawValues.size() ? CmsCsvImportUtils.normalizeToken(rawValues.get(i)) : "";
+            if (value == null) {
+                value = "";
+            }
+            if ("password".equals(column)
+                && (CmsStringUtil.isEmptyOrWhitespaceOnly(value) || !keepPasswordIfPossible)) {
+                value = m_password.getValue();
+            }
+            setUserValue(user, column, value, lineNumber);
+        }
+        if (CmsStringUtil.isEmptyOrWhitespaceOnly(user.getName())) {
+            throw new IllegalArgumentException("CSV line " + lineNumber + " does not contain a user name.");
+        }
+        if (CmsStringUtil.isEmptyOrWhitespaceOnly(user.getPassword())) {
+            user.setPassword(m_password.getValue());
+        }
+        return user;
+    }
+
+    private void setUserValue(CmsUser user, String column, String value, int lineNumber) {
+
+        if (CmsStringUtil.isEmptyOrWhitespaceOnly(value) || "null".equals(value)) {
+            return;
+        }
+        try {
+            Method method = CmsUser.class.getMethod(
+                "set" + column.substring(0, 1).toUpperCase() + column.substring(1),
+                new Class[] {String.class});
+            method.invoke(user, new Object[] {value});
+        } catch (NoSuchMethodException e) {
+            user.setAdditionalInfo(column, value);
+        } catch (IllegalAccessException e) {
+            throw new IllegalArgumentException(
+                "CSV line " + lineNumber + ": field '" + column + "' is not accessible.",
+                e);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause() == null ? e : e.getCause();
+            throw new IllegalArgumentException(
+                "CSV line " + lineNumber + ": invalid value for field '" + column + "'.",
+                cause);
+        } catch (CmsRuntimeException e) {
+            throw new IllegalArgumentException(
+                "CSV line " + lineNumber + ": unable to set field '" + column + "'.",
+                e);
+        }
+    }
+
+    private void validateHeader(List<String> columns) {
+
+        if (!columns.contains("name")) {
+            throw new IllegalArgumentException("The mandatory CSV column 'name' is missing.");
+        }
+        if (!columns.contains("password")) {
+            LOG.warn(
+                "CSV user import does not contain a password column. The password configured in the dialog will be used for all users.");
+        }
+    }
+
     protected void importUserFromFile() {
 
         CmsImportUserThread thread = new CmsImportUserThread(
@@ -642,50 +484,37 @@ implements Receiver, I_CmsPasswordFetcher {
             }
         });
         m_window.setContent(dialog);
-
     }
 
-    /**
-     * @see org.opencms.ui.apps.user.A_CmsImportExportUserDialog#getCloseButton()
-     */
     @Override
     Button getCloseButton() {
 
         return m_cancel;
     }
 
-    /**
-     * @see org.opencms.ui.apps.user.A_CmsImportExportUserDialog#getDownloadButton()
-     */
     @Override
     Button getDownloadButton() {
 
         return m_download;
     }
 
-    /**
-     * @see org.opencms.ui.apps.user.A_CmsImportExportUserDialog#getUserToExport()
-     */
     @Override
     Map<CmsUUID, CmsUser> getUserToExport() {
 
-        // get the data object from session
         List<String> groups = getGroupsList(m_exportGroups, false);
-
         Iterator<I_CmsEditableGroupRow> it = m_exportRolesGroup.getRows().iterator();
         List<String> roles = new ArrayList<String>();
         while (it.hasNext()) {
             CmsRole role = (CmsRole)((ComboBox)it.next().getComponent()).getValue();
             roles.add(role.getGroupName());
         }
-
         Map<CmsUUID, CmsUser> exportUsers = new HashMap<CmsUUID, CmsUser>();
         try {
-            if (((groups.size() < 1)) && ((roles.size() < 1))) {
-                exportUsers = CmsImportExportUserDialog.addExportAllUsers(m_cms, m_ou, exportUsers);
+            if ((groups.size() < 1) && (roles.size() < 1)) {
+                exportUsers = addExportAllUsers(m_cms, m_ou, exportUsers);
             } else {
-                exportUsers = CmsImportExportUserDialog.addExportUsersFromGroups(m_cms, groups, exportUsers);
-                exportUsers = CmsImportExportUserDialog.addExportUsersFromRoles(m_cms, m_ou, roles, exportUsers);
+                exportUsers = addExportUsersFromGroups(m_cms, groups, exportUsers);
+                exportUsers = addExportUsersFromRoles(m_cms, m_ou, roles, exportUsers);
             }
         } catch (CmsException e) {
             LOG.error("Unable to get export user list.", e);
@@ -693,77 +522,51 @@ implements Receiver, I_CmsPasswordFetcher {
         return exportUsers;
     }
 
-    /**
-     * @see org.opencms.ui.apps.user.A_CmsImportExportUserDialog#isExportWithTechnicalFields()
-     */
     @Override
     boolean isExportWithTechnicalFields() {
 
         return m_includeTechnicalFields.getValue().booleanValue();
     }
 
-    /**
-     * Gets selected groups in List.<p>
-     *
-     * @param parent layout
-     * @param importCase boolean
-     * @return List of group names
-     */
     private List<String> getGroupsList(VerticalLayout parent, boolean importCase) {
 
-        List<String> res = new ArrayList<String>();
-
+        List<String> result = new ArrayList<String>();
         if (m_groupID != null) {
             try {
-                res.add(m_cms.readGroup(m_groupID).getName());
+                result.add(m_cms.readGroup(m_groupID).getName());
             } catch (CmsException e) {
                 LOG.error("Unable to read group", e);
             }
-            return res;
+            return result;
         }
-
         if (m_groupEditable) {
             CmsEditableGroup editableGroup = importCase ? m_importGroupsGroup : m_exportGroupsGroup;
             for (I_CmsEditableGroupRow row : editableGroup.getRows()) {
                 String groupName = ((CmsPrincipalSelect)row.getComponent()).getValue();
                 if (!CmsStringUtil.isEmptyOrWhitespaceOnly(groupName)) {
-                    res.add(groupName);
+                    result.add(groupName);
                 }
             }
         } else {
-            TextField comp = (TextField)parent.getComponent(0);
-            res.add(comp.getValue());
+            TextField component = (TextField)parent.getComponent(0);
+            result.add(component.getValue());
         }
-        return res;
+        return result;
     }
 
-    /**
-     * Get selected roles list.<p>
-     *
-     * @param parent layout
-     * @param importCase boolean
-     * @return List of roles
-     */
     private List<CmsRole> getRolesList(VerticalLayout parent, boolean importCase) {
 
-        List<CmsRole> res = new ArrayList<CmsRole>();
-
+        List<CmsRole> result = new ArrayList<CmsRole>();
         CmsEditableGroup editableGroup = importCase ? m_importRolesGroup : m_exportRolesGroup;
         for (I_CmsEditableGroupRow row : editableGroup.getRows()) {
-            res.add(((ComboBox<CmsRole>)row.getComponent()).getValue());
+            result.add(((ComboBox<CmsRole>)row.getComponent()).getValue());
         }
-        return res;
+        return result;
     }
 
-    /**
-     * Set the visibility of the buttons.<p>
-     *
-     * @param tab which is selected.
-     */
     private void setButtonVisibility(int tab) {
 
         m_download.setVisible(tab == 1);
         m_startImport.setVisible(tab == 0);
-
     }
 }

--- a/src/org/opencms/ui/apps/user/CmsImportUserThread.java
+++ b/src/org/opencms/ui/apps/user/CmsImportUserThread.java
@@ -41,6 +41,7 @@ import org.opencms.ui.A_CmsUI;
 import org.opencms.ui.apps.CmsFileExplorerConfiguration;
 import org.opencms.ui.apps.CmsPageEditorConfiguration;
 import org.opencms.ui.apps.Messages;
+import org.opencms.util.CmsStringUtil;
 import org.opencms.util.CmsUUID;
 
 import java.util.ArrayList;
@@ -119,91 +120,184 @@ public class CmsImportUserThread extends A_CmsReportThread {
         getReport().println(
             Messages.get().container(Messages.RPT_USERIMPORT_FILE_CONTAINS_1, String.valueOf(m_userList.size())),
             I_CmsReport.FORMAT_DEFAULT);
+
         Iterator<CmsUser> itUsers = m_userList.iterator();
         while (itUsers.hasNext()) {
             CmsUser user = itUsers.next();
-            CmsUser createdUser = null;
-            if (!isAlreadyAvailable(user.getName())) {
-
-                String password = user.getPassword();
-
-                if (password.indexOf("_") == -1) {
-                    try {
-
-                        password = OpenCms.getPasswordHandler().digest(password);
-
-                        if (m_sendMail) {
-                            CmsUserEditDialog.sendMail(getCms(), user.getPassword(), user, m_ou, true, false);
-                        }
-                    } catch (CmsPasswordEncryptionException e) {
-                        //
-                    }
-                } else {
-                    password = password.substring(password.indexOf("_") + 1);
-                    if (m_sendMail) {
-                        CmsUserEditDialog.sendMail(getCms(), "your old password", user, m_ou, true, false);
-                    }
-                }
-
-                try {
-                    createdUser = getCms().importUser(
-                        new CmsUUID().toString(),
-                        m_ou + user.getName(),
-                        password,
-                        user.getFirstname(),
-                        user.getLastname(),
-                        user.getEmail(),
-                        user.getFlags(),
-                        System.currentTimeMillis(),
-                        user.getAdditionalInfo());
-
-                    if (!m_groupList.isEmpty()) {
-
-                        Iterator<String> itGroups = m_groupList.iterator();
-                        while (itGroups.hasNext()) {
-                            try {
-                                getCms().addUserToGroup(createdUser.getName(), itGroups.next());
-                            } catch (CmsException e) {
-                                //
-                            }
-                        }
-                    }
-
-                    if (!m_roleList.isEmpty()) {
-                        Iterator<CmsRole> itRoles = m_roleList.iterator();
-                        while (itRoles.hasNext()) {
-
-                            OpenCms.getRoleManager().addUserToRole(
-                                getCms(),
-                                itRoles.next().forOrgUnit(m_ou),
-                                createdUser.getName());
-
-                        }
-
-                    }
-                    String startAppId = CmsPageEditorConfiguration.APP_ID;
-                    if (OpenCms.getRoleManager().hasRole(getCms(), createdUser.getName(), CmsRole.WORKPLACE_USER)) {
-                        startAppId = CmsFileExplorerConfiguration.APP_ID;
-                    }
-                    CmsUserSettings settings = new CmsUserSettings(createdUser);
-                    settings.setStartView(startAppId);
-                    settings.setStartProject("Offline");
-                    settings.save(getCms());
-                } catch (CmsException e) {
-                    LOG.error("Unable to create user", e);
-                }
-                if (createdUser != null) {
-                    getReport().println(
-                        Messages.get().container(Messages.RPT_USERIMPORT_IMPORT_SUCCESFULL_1, createdUser.getName()),
-                        I_CmsReport.FORMAT_OK);
-                }
-            } else {
+            try {
+                importUser(user);
+            } catch (RuntimeException e) {
+                String userName = user == null ? "<null>" : String.valueOf(user.getName());
+                LOG.error("Unexpected error while importing user '" + userName + "' into OU '" + m_ou + "'.", e);
                 getReport().println(
-                    Messages.get().container(Messages.RPT_USERIMPORT_IMPORT_ALREADY_IN_OU_1, user.getName()),
+                    "Unable to import user '" + userName + "'. See the OpenCms log for details.",
                     I_CmsReport.FORMAT_ERROR);
             }
         }
         getReport().println(Messages.get().container(Messages.RPT_USERIMPORT_END_0), I_CmsReport.FORMAT_DEFAULT);
+    }
+
+    /**
+     * Imports a single user.<p>
+     *
+     * @param user the user data parsed from the CSV file
+     */
+    private void importUser(CmsUser user) {
+
+        if (user == null) {
+            LOG.error("Unable to import null user into OU '" + m_ou + "'.");
+            getReport().println("Unable to import an empty user record.", I_CmsReport.FORMAT_ERROR);
+            return;
+        }
+
+        String userName = user.getName();
+        if (CmsStringUtil.isEmptyOrWhitespaceOnly(userName)) {
+            LOG.error("Unable to import user without name into OU '" + m_ou + "'.");
+            getReport().println("Unable to import user: the user name is empty.", I_CmsReport.FORMAT_ERROR);
+            return;
+        }
+
+        if (isAlreadyAvailable(userName)) {
+            getReport().println(
+                Messages.get().container(Messages.RPT_USERIMPORT_IMPORT_ALREADY_IN_OU_1, userName),
+                I_CmsReport.FORMAT_ERROR);
+            return;
+        }
+
+        String sourcePassword = user.getPassword();
+        if (CmsStringUtil.isEmptyOrWhitespaceOnly(sourcePassword)) {
+            LOG.error("Unable to import user '" + userName + "': no password was supplied by the CSV import.");
+            getReport().println(
+                "Unable to import user '" + userName + "': password is empty.",
+                I_CmsReport.FORMAT_ERROR);
+            return;
+        }
+
+        String password = sourcePassword;
+        String mailPassword = sourcePassword;
+        if (password.indexOf('_') == -1) {
+            try {
+                password = OpenCms.getPasswordHandler().digest(password);
+            } catch (CmsPasswordEncryptionException e) {
+                LOG.error("Unable to encrypt password for user '" + userName + "'.", e);
+                getReport().println(
+                    "Unable to import user '" + userName + "': password encryption failed.",
+                    I_CmsReport.FORMAT_ERROR);
+                return;
+            }
+        } else {
+            password = password.substring(password.indexOf('_') + 1);
+            mailPassword = "your old password";
+        }
+
+        CmsUser createdUser;
+        try {
+            createdUser = getCms().importUser(
+                new CmsUUID().toString(),
+                m_ou + userName,
+                password,
+                user.getFirstname(),
+                user.getLastname(),
+                user.getEmail(),
+                user.getFlags(),
+                System.currentTimeMillis(),
+                user.getAdditionalInfo());
+        } catch (CmsException e) {
+            LOG.error("Unable to create user '" + userName + "' in OU '" + m_ou + "'.", e);
+            getReport().println(
+                "Unable to create user '" + userName + "'. See the OpenCms log for details.",
+                I_CmsReport.FORMAT_ERROR);
+            return;
+        }
+
+        addGroups(createdUser);
+        addRoles(createdUser);
+        saveUserSettings(createdUser);
+
+        if (m_sendMail) {
+            try {
+                CmsUserEditDialog.sendMail(getCms(), mailPassword, user, m_ou, true, false);
+            } catch (RuntimeException e) {
+                LOG.error("User '" + createdUser.getName() + "' was created, but the notification email could not be sent.", e);
+                getReport().println(
+                    "User '" + createdUser.getName() + "' was created, but the notification email failed.",
+                    I_CmsReport.FORMAT_WARNING);
+            }
+        }
+
+        getReport().println(
+            Messages.get().container(Messages.RPT_USERIMPORT_IMPORT_SUCCESFULL_1, createdUser.getName()),
+            I_CmsReport.FORMAT_OK);
+    }
+
+    /**
+     * Adds the imported user to the selected groups.<p>
+     *
+     * @param createdUser the imported user
+     */
+    private void addGroups(CmsUser createdUser) {
+
+        Iterator<String> itGroups = m_groupList.iterator();
+        while (itGroups.hasNext()) {
+            String groupName = itGroups.next();
+            try {
+                getCms().addUserToGroup(createdUser.getName(), groupName);
+            } catch (CmsException e) {
+                LOG.error(
+                    "Unable to add imported user '" + createdUser.getName() + "' to group '" + groupName + "'.",
+                    e);
+                getReport().println(
+                    "User '" + createdUser.getName() + "' could not be added to group '" + groupName + "'.",
+                    I_CmsReport.FORMAT_WARNING);
+            }
+        }
+    }
+
+    /**
+     * Adds the imported user to the selected roles.<p>
+     *
+     * @param createdUser the imported user
+     */
+    private void addRoles(CmsUser createdUser) {
+
+        Iterator<CmsRole> itRoles = m_roleList.iterator();
+        while (itRoles.hasNext()) {
+            CmsRole role = itRoles.next();
+            try {
+                OpenCms.getRoleManager().addUserToRole(getCms(), role.forOrgUnit(m_ou), createdUser.getName());
+            } catch (CmsException e) {
+                LOG.error(
+                    "Unable to add imported user '" + createdUser.getName() + "' to role '" + role + "'.",
+                    e);
+                getReport().println(
+                    "User '" + createdUser.getName() + "' could not be added to role '" + role + "'.",
+                    I_CmsReport.FORMAT_WARNING);
+            }
+        }
+    }
+
+    /**
+     * Saves the default workplace settings for the imported user.<p>
+     *
+     * @param createdUser the imported user
+     */
+    private void saveUserSettings(CmsUser createdUser) {
+
+        try {
+            String startAppId = CmsPageEditorConfiguration.APP_ID;
+            if (OpenCms.getRoleManager().hasRole(getCms(), createdUser.getName(), CmsRole.WORKPLACE_USER)) {
+                startAppId = CmsFileExplorerConfiguration.APP_ID;
+            }
+            CmsUserSettings settings = new CmsUserSettings(createdUser);
+            settings.setStartView(startAppId);
+            settings.setStartProject("Offline");
+            settings.save(getCms());
+        } catch (CmsException e) {
+            LOG.error("Unable to save settings for imported user '" + createdUser.getName() + "'.", e);
+            getReport().println(
+                "User '" + createdUser.getName() + "' was created, but its workplace settings could not be saved.",
+                I_CmsReport.FORMAT_WARNING);
+        }
     }
 
     /**
@@ -218,6 +312,7 @@ public class CmsImportUserThread extends A_CmsReportThread {
         try {
             availableUsers = OpenCms.getOrgUnitManager().getUsers(getCms(), m_ou, false);
         } catch (CmsException e) {
+            LOG.error("Unable to read users from OU '" + m_ou + "' while checking user '" + userName + "'.", e);
             availableUsers = new ArrayList<CmsUser>();
         }
         Iterator<CmsUser> itAvailableUsers = availableUsers.iterator();
@@ -228,5 +323,4 @@ public class CmsImportUserThread extends A_CmsReportThread {
         }
         return false;
     }
-
 }

--- a/src/org/opencms/ui/apps/user/CmsImportUserThread.java
+++ b/src/org/opencms/ui/apps/user/CmsImportUserThread.java
@@ -92,9 +92,9 @@ public class CmsImportUserThread extends A_CmsReportThread {
         boolean sendmail) {
 
         super(cms, "importUser");
-        m_userList = userList;
-        m_roleList = roles;
-        m_groupList = groups;
+        m_userList = userList == null ? new ArrayList<CmsUser>() : userList;
+        m_roleList = roles == null ? new ArrayList<CmsRole>() : roles;
+        m_groupList = groups == null ? new ArrayList<String>() : groups;
         m_ou = ou;
         m_sendMail = sendmail;
         initHtmlReport(A_CmsUI.get().getLocale());
@@ -130,174 +130,11 @@ public class CmsImportUserThread extends A_CmsReportThread {
                 String userName = user == null ? "<null>" : String.valueOf(user.getName());
                 LOG.error("Unexpected error while importing user '" + userName + "' into OU '" + m_ou + "'.", e);
                 getReport().println(
-                    "Unable to import user '" + userName + "'. See the OpenCms log for details.",
+                    Messages.get().container(Messages.RPT_USERIMPORT_IMPORT_FAILED_1, userName),
                     I_CmsReport.FORMAT_ERROR);
             }
         }
         getReport().println(Messages.get().container(Messages.RPT_USERIMPORT_END_0), I_CmsReport.FORMAT_DEFAULT);
-    }
-
-    /**
-     * Imports a single user.<p>
-     *
-     * @param user the user data parsed from the CSV file
-     */
-    private void importUser(CmsUser user) {
-
-        if (user == null) {
-            LOG.error("Unable to import null user into OU '" + m_ou + "'.");
-            getReport().println("Unable to import an empty user record.", I_CmsReport.FORMAT_ERROR);
-            return;
-        }
-
-        String userName = user.getName();
-        if (CmsStringUtil.isEmptyOrWhitespaceOnly(userName)) {
-            LOG.error("Unable to import user without name into OU '" + m_ou + "'.");
-            getReport().println("Unable to import user: the user name is empty.", I_CmsReport.FORMAT_ERROR);
-            return;
-        }
-
-        if (isAlreadyAvailable(userName)) {
-            getReport().println(
-                Messages.get().container(Messages.RPT_USERIMPORT_IMPORT_ALREADY_IN_OU_1, userName),
-                I_CmsReport.FORMAT_ERROR);
-            return;
-        }
-
-        String sourcePassword = user.getPassword();
-        if (CmsStringUtil.isEmptyOrWhitespaceOnly(sourcePassword)) {
-            LOG.error("Unable to import user '" + userName + "': no password was supplied by the CSV import.");
-            getReport().println(
-                "Unable to import user '" + userName + "': password is empty.",
-                I_CmsReport.FORMAT_ERROR);
-            return;
-        }
-
-        String password = sourcePassword;
-        String mailPassword = sourcePassword;
-        if (password.indexOf('_') == -1) {
-            try {
-                password = OpenCms.getPasswordHandler().digest(password);
-            } catch (CmsPasswordEncryptionException e) {
-                LOG.error("Unable to encrypt password for user '" + userName + "'.", e);
-                getReport().println(
-                    "Unable to import user '" + userName + "': password encryption failed.",
-                    I_CmsReport.FORMAT_ERROR);
-                return;
-            }
-        } else {
-            password = password.substring(password.indexOf('_') + 1);
-            mailPassword = "your old password";
-        }
-
-        CmsUser createdUser;
-        try {
-            createdUser = getCms().importUser(
-                new CmsUUID().toString(),
-                m_ou + userName,
-                password,
-                user.getFirstname(),
-                user.getLastname(),
-                user.getEmail(),
-                user.getFlags(),
-                System.currentTimeMillis(),
-                user.getAdditionalInfo());
-        } catch (CmsException e) {
-            LOG.error("Unable to create user '" + userName + "' in OU '" + m_ou + "'.", e);
-            getReport().println(
-                "Unable to create user '" + userName + "'. See the OpenCms log for details.",
-                I_CmsReport.FORMAT_ERROR);
-            return;
-        }
-
-        addGroups(createdUser);
-        addRoles(createdUser);
-        saveUserSettings(createdUser);
-
-        if (m_sendMail) {
-            try {
-                CmsUserEditDialog.sendMail(getCms(), mailPassword, user, m_ou, true, false);
-            } catch (RuntimeException e) {
-                LOG.error("User '" + createdUser.getName() + "' was created, but the notification email could not be sent.", e);
-                getReport().println(
-                    "User '" + createdUser.getName() + "' was created, but the notification email failed.",
-                    I_CmsReport.FORMAT_WARNING);
-            }
-        }
-
-        getReport().println(
-            Messages.get().container(Messages.RPT_USERIMPORT_IMPORT_SUCCESFULL_1, createdUser.getName()),
-            I_CmsReport.FORMAT_OK);
-    }
-
-    /**
-     * Adds the imported user to the selected groups.<p>
-     *
-     * @param createdUser the imported user
-     */
-    private void addGroups(CmsUser createdUser) {
-
-        Iterator<String> itGroups = m_groupList.iterator();
-        while (itGroups.hasNext()) {
-            String groupName = itGroups.next();
-            try {
-                getCms().addUserToGroup(createdUser.getName(), groupName);
-            } catch (CmsException e) {
-                LOG.error(
-                    "Unable to add imported user '" + createdUser.getName() + "' to group '" + groupName + "'.",
-                    e);
-                getReport().println(
-                    "User '" + createdUser.getName() + "' could not be added to group '" + groupName + "'.",
-                    I_CmsReport.FORMAT_WARNING);
-            }
-        }
-    }
-
-    /**
-     * Adds the imported user to the selected roles.<p>
-     *
-     * @param createdUser the imported user
-     */
-    private void addRoles(CmsUser createdUser) {
-
-        Iterator<CmsRole> itRoles = m_roleList.iterator();
-        while (itRoles.hasNext()) {
-            CmsRole role = itRoles.next();
-            try {
-                OpenCms.getRoleManager().addUserToRole(getCms(), role.forOrgUnit(m_ou), createdUser.getName());
-            } catch (CmsException e) {
-                LOG.error(
-                    "Unable to add imported user '" + createdUser.getName() + "' to role '" + role + "'.",
-                    e);
-                getReport().println(
-                    "User '" + createdUser.getName() + "' could not be added to role '" + role + "'.",
-                    I_CmsReport.FORMAT_WARNING);
-            }
-        }
-    }
-
-    /**
-     * Saves the default workplace settings for the imported user.<p>
-     *
-     * @param createdUser the imported user
-     */
-    private void saveUserSettings(CmsUser createdUser) {
-
-        try {
-            String startAppId = CmsPageEditorConfiguration.APP_ID;
-            if (OpenCms.getRoleManager().hasRole(getCms(), createdUser.getName(), CmsRole.WORKPLACE_USER)) {
-                startAppId = CmsFileExplorerConfiguration.APP_ID;
-            }
-            CmsUserSettings settings = new CmsUserSettings(createdUser);
-            settings.setStartView(startAppId);
-            settings.setStartProject("Offline");
-            settings.save(getCms());
-        } catch (CmsException e) {
-            LOG.error("Unable to save settings for imported user '" + createdUser.getName() + "'.", e);
-            getReport().println(
-                "User '" + createdUser.getName() + "' was created, but its workplace settings could not be saved.",
-                I_CmsReport.FORMAT_WARNING);
-        }
     }
 
     /**
@@ -322,5 +159,179 @@ public class CmsImportUserThread extends A_CmsReportThread {
             }
         }
         return false;
+    }
+
+    /**
+     * Adds the imported user to the selected groups.<p>
+     *
+     * @param createdUser the imported user
+     */
+    private void addGroups(CmsUser createdUser) {
+
+        Iterator<String> itGroups = m_groupList.iterator();
+        while (itGroups.hasNext()) {
+            String groupName = itGroups.next();
+            try {
+                getCms().addUserToGroup(createdUser.getName(), groupName);
+            } catch (CmsException e) {
+                LOG.error(
+                    "Unable to add imported user '" + createdUser.getName() + "' to group '" + groupName + "'.",
+                    e);
+                getReport().println(
+                    Messages.get().container(Messages.RPT_USERIMPORT_GROUP_FAILED_2, createdUser.getName(), groupName),
+                    I_CmsReport.FORMAT_WARNING);
+            }
+        }
+    }
+
+    /**
+     * Adds the imported user to the selected roles.<p>
+     *
+     * @param createdUser the imported user
+     */
+    private void addRoles(CmsUser createdUser) {
+
+        Iterator<CmsRole> itRoles = m_roleList.iterator();
+        while (itRoles.hasNext()) {
+            CmsRole role = itRoles.next();
+            try {
+                OpenCms.getRoleManager().addUserToRole(getCms(), role.forOrgUnit(m_ou), createdUser.getName());
+            } catch (CmsException e) {
+                LOG.error("Unable to add imported user '" + createdUser.getName() + "' to role '" + role + "'.", e);
+                getReport().println(
+                    Messages.get().container(Messages.RPT_USERIMPORT_ROLE_FAILED_2, createdUser.getName(), role),
+                    I_CmsReport.FORMAT_WARNING);
+            }
+        }
+    }
+
+    /**
+     * Imports a single user.<p>
+     *
+     * @param user the user data parsed from the CSV file
+     */
+    private void importUser(CmsUser user) {
+
+        if (user == null) {
+            LOG.error("Unable to import null user into OU '" + m_ou + "'.");
+            getReport().println(
+                Messages.get().container(Messages.RPT_USERIMPORT_IMPORT_EMPTY_RECORD_0),
+                I_CmsReport.FORMAT_ERROR);
+            return;
+        }
+
+        String userName = user.getName();
+        if (CmsStringUtil.isEmptyOrWhitespaceOnly(userName)) {
+            LOG.error("Unable to import user without name into OU '" + m_ou + "'.");
+            getReport().println(
+                Messages.get().container(Messages.RPT_USERIMPORT_IMPORT_EMPTY_NAME_0),
+                I_CmsReport.FORMAT_ERROR);
+            return;
+        }
+
+        if (isAlreadyAvailable(userName)) {
+            getReport().println(
+                Messages.get().container(Messages.RPT_USERIMPORT_IMPORT_ALREADY_IN_OU_1, userName),
+                I_CmsReport.FORMAT_ERROR);
+            return;
+        }
+
+        String sourcePassword = user.getPassword();
+        if (CmsStringUtil.isEmptyOrWhitespaceOnly(sourcePassword)) {
+            LOG.error("Unable to import user '" + userName + "': no password was supplied by the CSV import.");
+            getReport().println(
+                Messages.get().container(Messages.RPT_USERIMPORT_PASSWORD_EMPTY_1, userName),
+                I_CmsReport.FORMAT_ERROR);
+            return;
+        }
+
+        String password = sourcePassword;
+        String mailPassword = sourcePassword;
+        if (password.indexOf('_') == -1) {
+            try {
+                password = OpenCms.getPasswordHandler().digest(password);
+            } catch (CmsPasswordEncryptionException e) {
+                LOG.error("Unable to encrypt password for user '" + userName + "'.", e);
+                getReport().println(
+                    Messages.get().container(Messages.RPT_USERIMPORT_PASSWORD_ENCRYPTION_FAILED_1, userName),
+                    I_CmsReport.FORMAT_ERROR);
+                return;
+            }
+        } else {
+            password = password.substring(password.indexOf('_') + 1);
+            if (CmsStringUtil.isEmptyOrWhitespaceOnly(password)) {
+                LOG.error("Unable to import user '" + userName + "': encrypted password value is empty.");
+                getReport().println(
+                    Messages.get().container(Messages.RPT_USERIMPORT_PASSWORD_EMPTY_1, userName),
+                    I_CmsReport.FORMAT_ERROR);
+                return;
+            }
+            mailPassword = "your old password";
+        }
+
+        CmsUser createdUser;
+        try {
+            createdUser = getCms().importUser(
+                new CmsUUID().toString(),
+                m_ou + userName,
+                password,
+                user.getFirstname(),
+                user.getLastname(),
+                user.getEmail(),
+                user.getFlags(),
+                System.currentTimeMillis(),
+                user.getAdditionalInfo());
+        } catch (CmsException e) {
+            LOG.error("Unable to create user '" + userName + "' in OU '" + m_ou + "'.", e);
+            getReport().println(
+                Messages.get().container(Messages.RPT_USERIMPORT_IMPORT_CREATE_FAILED_1, userName),
+                I_CmsReport.FORMAT_ERROR);
+            return;
+        }
+
+        addGroups(createdUser);
+        addRoles(createdUser);
+        saveUserSettings(createdUser);
+
+        if (m_sendMail) {
+            try {
+                CmsUserEditDialog.sendMail(getCms(), mailPassword, createdUser, m_ou, true, false, true);
+            } catch (RuntimeException e) {
+                LOG.error(
+                    "User '" + createdUser.getName() + "' was created, but the notification email could not be sent.",
+                    e);
+                getReport().println(
+                    Messages.get().container(Messages.RPT_USERIMPORT_MAIL_FAILED_1, createdUser.getName()),
+                    I_CmsReport.FORMAT_WARNING);
+            }
+        }
+
+        getReport().println(
+            Messages.get().container(Messages.RPT_USERIMPORT_IMPORT_SUCCESFULL_1, createdUser.getName()),
+            I_CmsReport.FORMAT_OK);
+    }
+
+    /**
+     * Saves the default workplace settings for the imported user.<p>
+     *
+     * @param createdUser the imported user
+     */
+    private void saveUserSettings(CmsUser createdUser) {
+
+        try {
+            String startAppId = CmsPageEditorConfiguration.APP_ID;
+            if (OpenCms.getRoleManager().hasRole(getCms(), createdUser.getName(), CmsRole.WORKPLACE_USER)) {
+                startAppId = CmsFileExplorerConfiguration.APP_ID;
+            }
+            CmsUserSettings settings = new CmsUserSettings(createdUser);
+            settings.setStartView(startAppId);
+            settings.setStartProject("Offline");
+            settings.save(getCms());
+        } catch (CmsException e) {
+            LOG.error("Unable to save settings for imported user '" + createdUser.getName() + "'.", e);
+            getReport().println(
+                Messages.get().container(Messages.RPT_USERIMPORT_SETTINGS_FAILED_1, createdUser.getName()),
+                I_CmsReport.FORMAT_WARNING);
+        }
     }
 }

--- a/src/org/opencms/ui/apps/user/CmsUserEditDialog.java
+++ b/src/org/opencms/ui/apps/user/CmsUserEditDialog.java
@@ -693,6 +693,29 @@ public class CmsUserEditDialog extends CmsBasicDialog implements I_CmsPasswordFe
         boolean newUser,
         boolean changePassword) {
 
+        sendMail(cms, password, user, ou, newUser, changePassword, false);
+    }
+
+    /**
+     * Sends an email to the user.<p>
+     *
+     * @param cms CmsObject
+     * @param password of the user
+     * @param user user to send mail to
+     * @param ou name
+     * @param newUser flag indicates if user is new
+     * @param changePassword has the user to change password?
+     * @param throwOnError if the mail error should be propagated
+     */
+    protected static void sendMail(
+        CmsObject cms,
+        String password,
+        CmsUser user,
+        String ou,
+        boolean newUser,
+        boolean changePassword,
+        boolean throwOnError) {
+
         if (CmsStringUtil.isEmptyOrWhitespaceOnly(user.getEmail())) {
             return;
         }
@@ -708,6 +731,9 @@ public class CmsUserEditDialog extends CmsBasicDialog implements I_CmsPasswordFe
             notification.send();
         } catch (EmailException e) {
             LOG.error("Unable to send email with password", e);
+            if (throwOnError) {
+                throw new IllegalStateException("Unable to send email with password.", e);
+            }
         }
 
     }

--- a/test/org/opencms/ui/apps/user/TestCmsCsvImportUtils.java
+++ b/test/org/opencms/ui/apps/user/TestCmsCsvImportUtils.java
@@ -1,0 +1,259 @@
+/*
+ * This library is part of OpenCms -
+ * the Open Source Content Management System
+ *
+ * Copyright (c) Alkacon Software GmbH & Co. KG (https://www.alkacon.com)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * For further information about Alkacon Software GmbH & Co. KG, please see the
+ * company website: https://www.alkacon.com
+ *
+ * For further information about OpenCms, please see the
+ * project website: https://www.opencms.org
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+package org.opencms.ui.apps.user;
+
+import org.opencms.file.CmsUser;
+import org.opencms.main.OpenCmsCore;
+import org.opencms.security.CmsDefaultPasswordHandler;
+import org.opencms.security.CmsDefaultValidationHandler;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import junit.framework.TestCase;
+
+/**
+ * Tests CSV user import parsing.<p>
+ */
+public class TestCmsCsvImportUtils extends TestCase {
+
+    /** Default password for parser tests. */
+    private static final String DEFAULT_PASSWORD = "generated";
+
+    /**
+     * Sets a private field value.<p>
+     *
+     * @param target the target object
+     * @param fieldName the field name
+     * @param value the field value
+     *
+     * @throws Exception if setting the field fails
+     */
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+
+        Field field = OpenCmsCore.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    /**
+     * Tests empty user name rejection.<p>
+     */
+    public void testEmptyUserName() {
+
+        IllegalArgumentException exception = expectIllegalArgument("name;firstname;lastname\n;Ana;López", true);
+
+        assertEquals("CSV line 2 does not contain a user name.", exception.getMessage());
+    }
+
+    /**
+     * Tests missing name column rejection.<p>
+     */
+    public void testMissingNameColumn() {
+
+        IllegalArgumentException exception = expectIllegalArgument(
+            "firstname;lastname;email\nAna;López;ana@example.com",
+            true);
+
+        assertEquals("The mandatory CSV column 'name' is missing.", exception.getMessage());
+    }
+
+    /**
+     * Tests token normalization.<p>
+     */
+    public void testNormalizeToken() {
+
+        assertNull(CmsCsvImportUtils.normalizeToken(null));
+        assertEquals("name", CmsCsvImportUtils.normalizeToken("\ufeffname"));
+        assertEquals("name", CmsCsvImportUtils.normalizeToken("\"name\""));
+        assertEquals("name", CmsCsvImportUtils.normalizeToken("\ufeff\"name\""));
+    }
+
+    /**
+     * Tests password import handling.<p>
+     */
+    public void testPasswordImportHandling() {
+
+        CmsUser importedPassword = readOne("name;password\nuser1;csvPassword", true);
+        CmsUser defaultPassword = readOne("name;password\nuser1;csvPassword", false);
+
+        assertEquals("csvPassword", importedPassword.getPassword());
+        assertEquals(DEFAULT_PASSWORD, defaultPassword.getPassword());
+    }
+
+    /**
+     * Tests additional CSV columns.<p>
+     */
+    public void testReadAdditionalColumn() {
+
+        CmsUser user = readOne("name;firstname;customField\nuser1;Ana;customValue");
+
+        assertEquals("Ana", user.getFirstname());
+        assertEquals("customValue", user.getAdditionalInfo("customField"));
+    }
+
+    /**
+     * Tests UTF-8 CSV with BOM and unquoted headers.<p>
+     */
+    public void testReadBomWithoutQuotedHeader() {
+
+        CmsUser user = readOne("\ufeffname;firstname;lastname;email;password\nuser1;Ana;López;ana@example.com;");
+
+        assertEquals("user1", user.getName());
+        assertEquals("Ana", user.getFirstname());
+    }
+
+    /**
+     * Tests UTF-8 CSV with BOM and quoted headers.<p>
+     */
+    public void testReadBomWithQuotedHeader() {
+
+        CmsUser user = readOne(
+            "\ufeff\"name\";\"firstname\";\"lastname\";\"email\";\"password\"\nuser1;Ana;López;ana@example.com;");
+
+        assertEquals("user1", user.getName());
+        assertEquals("Ana", user.getFirstname());
+    }
+
+    /**
+     * Tests incomplete CSV rows.<p>
+     */
+    public void testReadIncompleteRow() {
+
+        CmsUser user = readOne("name;firstname;lastname;email\nuser1;Ana");
+
+        assertEquals("user1", user.getName());
+        assertEquals("Ana", user.getFirstname());
+        assertEquals("", user.getLastname());
+        assertEquals("", user.getEmail());
+    }
+
+    /**
+     * Tests UTF-8 CSV without BOM.<p>
+     */
+    public void testReadUtf8WithoutBom() {
+
+        CmsUser user = readOne("name;firstname;lastname;email;password\nuser1;Ana;López;ana@example.com;");
+
+        assertEquals("user1", user.getName());
+        assertEquals("Ana", user.getFirstname());
+        assertEquals("López", user.getLastname());
+        assertEquals("ana@example.com", user.getEmail());
+        assertEquals(DEFAULT_PASSWORD, user.getPassword());
+    }
+
+    /**
+     * Tests CSV without password column.<p>
+     */
+    public void testReadWithoutPasswordColumn() {
+
+        CmsUser user = readOne("name;firstname;lastname;email\nuser1;Ana;López;ana@example.com");
+
+        assertEquals(DEFAULT_PASSWORD, user.getPassword());
+    }
+
+    /**
+     * Installs the minimal OpenCms handlers needed by CmsUser setters.<p>
+     *
+     * @throws Exception if handler setup fails
+     */
+    @Override
+    protected void setUp() throws Exception {
+
+        super.setUp();
+        Method getInstance = OpenCmsCore.class.getDeclaredMethod("getInstance");
+        getInstance.setAccessible(true);
+        Object core = getInstance.invoke(null);
+        setField(core, "m_validationHandler", new CmsDefaultValidationHandler());
+        setField(core, "m_passwordHandler", new CmsDefaultPasswordHandler());
+    }
+
+    /**
+     * Expects CSV parsing to fail with an illegal argument exception.<p>
+     *
+     * @param csv the CSV text
+     * @param keepPasswordIfPossible true if CSV passwords should be imported
+     *
+     * @return the thrown exception
+     */
+    private IllegalArgumentException expectIllegalArgument(String csv, boolean keepPasswordIfPossible) {
+
+        try {
+            readUsers(csv, keepPasswordIfPossible);
+            fail("Expected IllegalArgumentException.");
+            return null;
+        } catch (IllegalArgumentException e) {
+            return e;
+        }
+    }
+
+    /**
+     * Reads one user from CSV.<p>
+     *
+     * @param csv the CSV text
+     *
+     * @return the parsed user
+     */
+    private CmsUser readOne(String csv) {
+
+        return readOne(csv, true);
+    }
+
+    /**
+     * Reads one user from CSV.<p>
+     *
+     * @param csv the CSV text
+     * @param keepPasswordIfPossible true if CSV passwords should be imported
+     *
+     * @return the parsed user
+     */
+    private CmsUser readOne(String csv, boolean keepPasswordIfPossible) {
+
+        List<CmsUser> users = readUsers(csv, keepPasswordIfPossible);
+        assertEquals(1, users.size());
+        return users.get(0);
+    }
+
+    /**
+     * Reads users from CSV.<p>
+     *
+     * @param csv the CSV text
+     * @param keepPasswordIfPossible true if CSV passwords should be imported
+     *
+     * @return the parsed users
+     */
+    private List<CmsUser> readUsers(String csv, boolean keepPasswordIfPossible) {
+
+        return CmsCsvImportUtils.readUsers(
+            csv.getBytes(StandardCharsets.UTF_8),
+            DEFAULT_PASSWORD,
+            keepPasswordIfPossible);
+    }
+}


### PR DESCRIPTION
This fixes CSV user imports for UTF-8 files with BOM when the first header is not quoted.

  The issue occurs with valid CSV files like:

  `name;firstname;lastname;email;password`

  When the file starts with a UTF-8 BOM, the importer reads the first column as `\ufeffname` instead of `name`. It then tries to resolve a dynamic setter for that field, fails to find the
  expected `CmsUser#setName(String)`, and the import can fail with unclear behavior.

  This PR:
  - removes an optional UTF-8 BOM from CSV headers and values, with both quoted and unquoted headers;
  - keeps the existing dynamic `CmsUser#setXxx(String)` reflection behavior;
  - keeps support for deployment-specific/custom CSV columns by storing fields without a matching setter as additional user info;
  - validates the mandatory `name` column and empty user names with clear errors;
  - handles incomplete rows without `IndexOutOfBoundsException`;
  - preserves and logs the real cause of setter invocation failures;
  - removes silent catches in the affected import flow;
  - sends notification emails only after the user has been created;
  - reports secondary failures for group, role, settings, or email operations without aborting the whole import;
  - avoids logging password values;
  - adds focused tests for BOM handling, variable columns, incomplete rows, missing `name`, and password fallback behavior.

  Validated with:
  - `./gradlew compileJava`
  - `./gradlew testSingle --tests org.opencms.ui.apps.user.TestCmsCsvImportUtils`

  Also manually tested on OpenCms 21.0.1 by replacing `opencms.jar` in a container.